### PR TITLE
D3ASIM-890: Added assertion on the storage state constructor with mor…

### DIFF
--- a/src/d3a/models/state.py
+++ b/src/d3a/models/state.py
@@ -92,6 +92,11 @@ class StorageState:
 
         if min_allowed_soc is None:
             min_allowed_soc = StorageSettings.MIN_ALLOWED_SOC
+
+        assert limit_float_precision(initial_capacity_kWh / capacity) >= min_allowed_soc, \
+            f"Initial capacity ({initial_capacity_kWh} kWh) exceeds the " \
+            f"min allowed soc ({min_allowed_soc*100.0}%)."
+
         self.min_allowed_soc = min_allowed_soc
 
         self.capacity = capacity

--- a/src/d3a/models/state.py
+++ b/src/d3a/models/state.py
@@ -94,7 +94,7 @@ class StorageState:
             min_allowed_soc = StorageSettings.MIN_ALLOWED_SOC
 
         assert limit_float_precision(initial_capacity_kWh / capacity) >= min_allowed_soc, \
-            f"Initial capacity ({initial_capacity_kWh} kWh) exceeds the " \
+            f"Initial capacity ({initial_capacity_kWh} kWh) is less than " \
             f"min allowed soc ({min_allowed_soc*100.0}%)."
 
         self.min_allowed_soc = min_allowed_soc


### PR DESCRIPTION
…e detailed explanation if the user has misconfigured the initial capacity of the storage to exceed the min allowed soc.

Sample output on the terminal:
...
  File "/Users/spyrostzavikas/dev/d3a/src/d3a/models/state.py", line 97, in __init__
    f"Initial capacity ({initial_capacity_kWh} kWh) exceeds the " \
AssertionError: Initial capacity (0.0 kWh) exceeds the min allowed soc (10.0%).