### PR TITLE
Feature/d3 asim 846

### DIFF
--- a/tools/pandapower_eval.py
+++ b/tools/pandapower_eval.py
@@ -1,3 +1,4 @@
+# In order to install PandaPower run 'pip install pandapower'
 import pandapower as pp
 from pandapower.plotting import to_html
 

--- a/tools/pandapower_eval.py
+++ b/tools/pandapower_eval.py
@@ -1,4 +1,4 @@
-# In order to install PandaPower run 'pip install pandapower'
+# In order to install PandaPower run 'pip install matplotlib pandapower'
 import pandapower as pp
 from pandapower.plotting import to_html
 

--- a/tools/pandapower_eval.py
+++ b/tools/pandapower_eval.py
@@ -1,0 +1,35 @@
+import pandapower as pp
+from pandapower.plotting import to_html
+
+
+# create empty net
+net = pp.create_empty_network()
+
+# create buses
+bus1 = pp.create_bus(net, vn_kv=20., name="Bus Grid 1")
+bus_trafo = pp.create_bus(net, vn_kv=0.4, name="Bus Trafo")
+bus_h1 = pp.create_bus(net, vn_kv=0.4, name="Bus House 1")
+bus_h2 = pp.create_bus(net, vn_kv=0.4, name="Bus House 2")
+
+# create bus elements
+pp.create_ext_grid(net, bus=bus1, vm_pu=1.0, name="Grid Connection")
+pp.create_load(net, bus=bus_h1, p_kw=0.1, q_kvar=0.005, name="H1 Load")
+pp.create_sgen(net, bus=bus_h1, p_kw=-0.1, name="H1 PV")
+pp.create_load(net, bus=bus_h2, p_kw=0.1, name="H2 Load")
+pp.create_storage(net, bus=bus_h2, p_kw=-0.1, max_e_kwh=3, name="H2 Storage")
+
+# create branch elements
+trafo = pp.create_transformer(net, hv_bus=bus1, lv_bus=bus_trafo,
+                              std_type="0.25 MVA 20/0.4 kV", name="Trafo")
+line = pp.create_line(net, from_bus=bus_h1, to_bus=bus_trafo,
+                      length_km=0.1, std_type="NAYY 4x150 SE", name="Line")
+line2 = pp.create_line(net, from_bus=bus_h2, to_bus=bus_trafo,
+                       length_km=0.1, std_type="NAYY 4x150 SE", name="Line")
+
+pp.runpp(net)
+
+print(net.res_load)
+print(net.res_sgen)
+print(net.res_trafo)
+
+to_html(net, 'test.html')

--- a/tools/pypsa_eval.py
+++ b/tools/pypsa_eval.py
@@ -1,0 +1,28 @@
+import pypsa
+
+network = pypsa.Network()
+
+network.add("Bus", "Grid bus bar")
+network.add("Bus", "Outer Grid bus bar")
+network.add("Transformer", "Grid trafo", type="0.25 MVA 20/0.4 kV",
+            bus0="Outer Grid bus bar", bus1="Grid bus bar")
+network.add("Bus", "House 1 bus bar")
+network.add("Line", "Grid-House 1 Line", bus0="Grid bus bar",
+            bus1="House 1 bus bar", type="NAYY 4x150 SE")
+# network.add("Store", "House 1 Storage", bus="House 1 bus bar", e_cyclic=True, e_nom=100.)
+network.add("Load", "House 1 Load", bus="House 1 bus bar", p_set=0.1)
+network.add("Bus", "House 2 bus bar")
+network.add("Line", "Grid-House 2 Line", bus0="Grid bus bar",
+            bus1="House 2 bus bar", type="NAYY 4x150 SE")
+network.add("Load", "House 2 Load", bus="House 2 bus bar", p_set=0.1, control="PQ")
+network.add("Generator", "House 2 PV", bus="House 2 bus bar", p_nom=0.1)
+
+# Do a Newton-Raphson power flow
+network.pf()
+print(network.loads_t.p_set)
+
+print(network.lines.tail())
+
+print(network.loads)
+print(network.generators)
+print(network.transformers)

--- a/tools/pypsa_eval.py
+++ b/tools/pypsa_eval.py
@@ -1,28 +1,33 @@
+# In order to install PyPSA run 'pip install pypsa'
 import pypsa
+from pypsa.io import export_to_csv_folder
+
 
 network = pypsa.Network()
 
-network.add("Bus", "Grid bus bar")
-network.add("Bus", "Outer Grid bus bar")
-network.add("Transformer", "Grid trafo", type="0.25 MVA 20/0.4 kV",
-            bus0="Outer Grid bus bar", bus1="Grid bus bar")
-network.add("Bus", "House 1 bus bar")
+network.add("Bus", "Grid bus bar", v_nom=0.4)
+network.add("Generator", "Grid Slack", bus="Grid bus bar", control="Slack")
+network.add("Bus", "House 1 bus bar", v_nom=0.4)
+network.add("Bus", "House 2 bus bar", v_nom=0.4)
+
 network.add("Line", "Grid-House 1 Line", bus0="Grid bus bar",
             bus1="House 1 bus bar", type="NAYY 4x150 SE")
-# network.add("Store", "House 1 Storage", bus="House 1 bus bar", e_cyclic=True, e_nom=100.)
-network.add("Load", "House 1 Load", bus="House 1 bus bar", p_set=0.1)
-network.add("Bus", "House 2 bus bar")
 network.add("Line", "Grid-House 2 Line", bus0="Grid bus bar",
             bus1="House 2 bus bar", type="NAYY 4x150 SE")
-network.add("Load", "House 2 Load", bus="House 2 bus bar", p_set=0.1, control="PQ")
-network.add("Generator", "House 2 PV", bus="House 2 bus bar", p_nom=0.1)
+
+network.add("Load", "House 1 Load", bus="House 1 bus bar", p_set=0.3, control="PQ")
+network.add("StorageUnit", "House 1 Storage", bus="House 1 bus bar",
+            p_set=0.4, control="PV")
+network.add("Load", "House 2 Load", bus="House 2 bus bar", p_set=0.3, control="PQ")
+network.add("Generator", "House 2 PV", bus="House 2 bus bar",
+            p_set=0.2, control="PV")
 
 # Do a Newton-Raphson power flow
-network.pf()
-print(network.loads_t.p_set)
+network.lpf()
 
-print(network.lines.tail())
+print(network.buses_t["p"])
+print(network.loads_t["p"])
+print(network.generators_t["p"])
+print(network.storage_units_t["p"])
 
-print(network.loads)
-print(network.generators)
-print(network.transformers)
+export_to_csv_folder(network, "pypsa_output")


### PR DESCRIPTION
For this story I have created scripts that create minimal grid setups for PandaPower and PyPSA, in order to evaluate and to have a proof-of-concept for our cases. In order to run the scripts one has to install the corresponding python package first (I did not add either in the requirements yet because we need to decide which one to use first), therefore in order to test these one needs to 'pip install pypsa pandapower'. 
I am preparing a separate confluence page as we speak for documenting the results, but to our perspective the API of both tools is pretty similar, and it is quite easy to create clones of our setup files. The main difference that I noticed is that on PyPSA one needs to create a slack generator in order to simulate a 'main grid connection', because by default the buses operate according to the control mode of the connected devices/generators. This is not true in pandapower, where every bus bar tries to perform power flow and does not depend on its connected devices. Furthermore, I did not manage to tune PyPSA to perform nonlinear power flow, even though it should be possible according to documentation, therefore only the real part of the calculations take place (active power-frequency only, no reactive power and voltage calculations take place). Pandapower performs nonlinear power flow, therefore voltage results are available. 
Both tools have been configured to dump output files under d3a/tools/ directory, which display results of the simulation for all the components of the grid. 