### PR TITLE
D3ASIM-1199: Added price_energy_day results per area, instead of glob…

### DIFF
--- a/integration_tests/steps/integration_tests.py
+++ b/integration_tests/steps/integration_tests.py
@@ -330,7 +330,9 @@ def save_reported_energy_trade_profile(context):
 
 @when('the reported price energy day results are saved')
 def step_impl(context):
-    context.price_energy_day = deepcopy(context.simulation.endpoint_buffer.price_energy_day)
+    context.price_energy_day = deepcopy(
+        context.simulation.endpoint_buffer.price_energy_day.csv_output
+    )
 
 
 @when('the past markets are not kept in memory')
@@ -909,5 +911,5 @@ def identical_energy_trade_profiles(context):
 
 @then('the price energy day results are identical no matter if the past markets are kept')
 def indentical_price_energy_day(context):
-    price_energy_day = context.simulation.endpoint_buffer.price_energy_day
+    price_energy_day = context.simulation.endpoint_buffer.price_energy_day.csv_output
     assert len(DeepDiff(price_energy_day, context.price_energy_day)) == 0

--- a/src/d3a/d3a_core/sim_results/area_statistics.py
+++ b/src/d3a/d3a_core/sim_results/area_statistics.py
@@ -26,10 +26,10 @@ from d3a.models.strategy.load_hours import CellTowerLoadHoursStrategy, LoadHours
 from d3a.d3a_core.util import area_name_from_area_or_iaa_name, make_iaa_name, \
     round_floats_for_ui, add_or_create_key
 from d3a.constants import FLOATING_POINT_TOLERANCE
+from d3a.models.const import ConstSettings
 
 
 loads_avg_prices = namedtuple('loads_avg_prices', ['load', 'price'])
-prices_pv_stor_energy = namedtuple('prices_pv_stor_energy', ['price', 'pv_energ', 'stor_energ'])
 
 
 def gather_area_loads_and_trade_prices(area, load_price_lists):
@@ -54,52 +54,6 @@ def gather_area_loads_and_trade_prices(area, load_price_lists):
         else:
             load_price_lists = gather_area_loads_and_trade_prices(child, load_price_lists)
     return load_price_lists
-
-
-def gather_prices_pv_storage_energy(area, price_energ_lists):
-    for child in area.children:
-        for market in child.parent.past_markets:
-            slot = market.time_slot
-            slot_time_str = "%02d:00" % slot.hour
-            calculate_prices_pv_storage_energy_one_market(child, market,
-                                                          price_energ_lists, slot_time_str)
-
-        if child.children != []:
-            price_energ_lists = gather_prices_pv_storage_energy(child, price_energ_lists)
-    return price_energ_lists
-
-
-def calculate_prices_pv_storage_energy_one_market(child, market, price_energ_lists, slot):
-    if slot not in price_energ_lists.keys():
-        price_energ_lists[slot] = prices_pv_stor_energy(price=[],
-                                                        pv_energ=[],
-                                                        stor_energ=[])
-    trade_prices = [
-        # Convert from cents to euro
-        t.offer.price / 100.0 / t.offer.energy
-        for t in market.trades
-        if t.buyer == child.name
-    ]
-    price_energ_lists[slot].price.extend(trade_prices)
-
-    if child.children == [] and isinstance(child.strategy, PVStrategy):
-        traded_energy = [
-            t.offer.energy
-            for t in market.trades
-            if t.seller == child.name
-        ]
-        price_energ_lists[slot].pv_energ.extend(traded_energy)
-
-    if child.children == [] and \
-            (isinstance(child.strategy, StorageStrategy)):
-        traded_energy = []
-
-        for t in market.trades:
-            if t.seller == child.name:
-                traded_energy.append(-t.offer.energy)
-            elif t.buyer == child.name:
-                traded_energy.append(t.offer.energy)
-        price_energ_lists[slot].stor_energ.extend(traded_energy)
 
 
 def export_cumulative_loads(area):
@@ -486,70 +440,65 @@ def export_cumulative_grid_trades_redis(area, accumulated_trades_redis, past_mar
                                                                              area, {})
 
 
-def export_price_energy_day(area):
-    price_lists = gather_prices_pv_storage_energy(area, OrderedDict())
-    return [
-        {
-            "timeslot": ii,
-            "time": hour,
-            "av_price": round(mean(trades.price) if len(trades.price) > 0 else 0, 2),
-            "min_price": round(min(trades.price) if len(trades.price) > 0 else 0, 2),
-            "max_price": round(max(trades.price) if len(trades.price) > 0 else 0, 2),
-            "cum_pv_gen": round(-1 * sum(trades.pv_energ), 2),
-            "cum_stor_prof": round(sum(trades.stor_energ), 2)
-        } for ii, (hour, trades) in enumerate(price_lists.items())
-    ]
-
-
 class MarketPriceEnergyDay:
     def __init__(self):
-        self.timeslot_results = {}
-        self.hourly_results = {
-            "price-currency": "Euros",
-            "load-unit": "kWh",
-            "price-energy-day": []
-        }
-
-    def update_and_get_last_past_market(self, area):
-        if len(area.past_markets) == 0:
-            return self.hourly_results
-
-        hour = area.past_markets[-1].time_slot.hour
-        hour_str = "%02d:00" % hour
-        # Keep only the current hour results to save memory
-        self.timeslot_results = {ts: trades
-                                 for ts, trades in self.timeslot_results.items()
-                                 if ts.hour == hour}
-        self.timeslot_results = self._gather_prices_pv_storage_energy_last_past_market(
-            area, self.timeslot_results
-        )
-        self.hourly_results["price-energy-day"] = [
-            r for r in self.hourly_results["price-energy-day"] if r["time"] is not hour_str
-        ]
-        current_hour_results = [{
-            "time": hour_str,
-            "av_price": round(mean(trades.price) if len(trades.price) > 0 else 0, 2),
-            "min_price": round(min(trades.price) if len(trades.price) > 0 else 0, 2),
-            "max_price": round(max(trades.price) if len(trades.price) > 0 else 0, 2),
-            "cum_pv_gen": round(-1 * sum(trades.pv_energ), 2),
-            "cum_stor_prof": round(sum(trades.stor_energ), 2)
-        } for ii, (timeslot, trades) in enumerate(self.timeslot_results.items())]
-        self.hourly_results["price-energy-day"].extend(current_hour_results)
-        # Populating timeslot properly according to the order of current_hour_results
-        self.hourly_results["price-energy-day"] = [
-            {"timeslot": i, **v} for i, v in enumerate(self.hourly_results["price-energy-day"])
-        ]
-        return self.hourly_results
+        self._price_energy_day = {}
+        self.csv_output = {}
+        self.redis_output = {}
 
     @classmethod
-    def _gather_prices_pv_storage_energy_last_past_market(cls, area, price_energ_lists):
-        for child in area.children:
-            market = child.parent.past_markets[-1]
-            slot = market.time_slot
-            calculate_prices_pv_storage_energy_one_market(child, market, price_energ_lists,
-                                                          slot)
+    def gather_trade_rates(cls, area, price_lists, use_last_past_market=False):
+        if area.children == []:
+            return price_lists
 
-            if child.children != []:
-                price_energ_lists = cls._gather_prices_pv_storage_energy_last_past_market(
-                    child, price_energ_lists)
-        return price_energ_lists
+        if use_last_past_market is False:
+            markets = area.past_markets
+        elif area.current_market is not None:
+            markets = [area.current_market]
+        else:
+            markets = []
+
+        for market in markets:
+            cls.gather_rates_one_market(area, market, price_lists)
+
+        for child in area.children:
+            price_lists = cls.gather_trade_rates(child, price_lists)
+
+        return price_lists
+
+    @classmethod
+    def gather_rates_one_market(cls, area, market, price_lists):
+        if area not in price_lists:
+            price_lists[area] = OrderedDict()
+        if market.time_slot_str not in price_lists.keys():
+            price_lists[area][market.time_slot_str] = []
+        trade_rates = [
+            # Convert from cents to euro
+            t.offer.price / 100.0 / t.offer.energy
+            for t in market.trades
+        ]
+        price_lists[area][market.time_slot_str].extend(trade_rates)
+
+    def update(self, area):
+        self._price_energy_day = self.gather_trade_rates(
+            area, self._price_energy_day,
+            use_last_past_market=not ConstSettings.GeneralSettings.KEEP_PAST_MARKETS
+        )
+        for node, trade_rates in self._price_energy_day.items():
+            if node.name not in self.csv_output:
+                self.csv_output[node.name] = {
+                    "price-currency": "Euros",
+                    "load-unit": "kWh",
+                    "price-energy-day": []
+                }
+            self.csv_output[node.name]["price-energy-day"] = [
+                {
+                    "time": timeslot,
+                    "av_price": round(mean(trades) if len(trades) > 0 else 0, 2),
+                    "min_price": round(min(trades) if len(trades) > 0 else 0, 2),
+                    "max_price": round(max(trades) if len(trades) > 0 else 0, 2),
+                } for timeslot, trades in trade_rates.items()
+            ]
+            self.redis_output[node.uuid] = deepcopy(self.csv_output[node.name])
+
+        return self.csv_output, self.redis_output

--- a/src/d3a/d3a_core/sim_results/endpoint_buffer.py
+++ b/src/d3a/d3a_core/sim_results/endpoint_buffer.py
@@ -154,15 +154,13 @@ class SimulationEndpointBuffer:
         price_energy_list = self.price_energy_day.csv_output
 
         def calculate_prices(key, functor):
-            # Need to convert to euro cents to avoid having to change the backend
-            # TODO: Both this and the frontend have to remove the recalculation
             if area.name not in price_energy_list:
                 return 0.
             energy_prices = [
                 price_energy[key]
                 for price_energy in price_energy_list[area.name]["price-energy-day"]
             ]
-            return round(100 * functor(energy_prices), 2) if len(energy_prices) > 0 else 0.0
+            return round(functor(energy_prices), 2) if len(energy_prices) > 0 else 0.0
 
         self.tree_summary[area.slug] = {
             "min_trade_price": calculate_prices("min_price", min),


### PR DESCRIPTION
…al results that were used until now. Removed the pv and storage statistics. Removed timeslot index. Added uuid output to be compatible with d3a-web/redis.