### PR TITLE
Changed validation when receiving a new bid and offer to also include…

### DIFF
--- a/src/d3a/constants.py
+++ b/src/d3a/constants.py
@@ -34,7 +34,7 @@ MAX_WORKER_THREADS = 10
 DISPATCH_EVENTS_BOTTOM_TO_TOP = True
 # Controls how often will event tick be dispatched to external connections. Defaults to
 # 20% of the slot length
-DISPATCH_EVENT_TICK_FREQUENCY_PERCENT = 20
+DISPATCH_EVENT_TICK_FREQUENCY_PERCENT = 10
 
 COLLABORATION_ID = ""
 # Controls whether the external connection is for use with the redis api client

--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -91,8 +91,13 @@ class LoadExternalMixin(ExternalMixin):
             arguments = json.loads(payload["data"])
             assert set(arguments.keys()) == {'price', 'energy'}
             arguments['buyer_origin'] = self.device.name
+            pending_bid_energy = sum(
+                req.arguments["energy"]
+                for req in self.pending_requests
+                if req.request_type == "bid"
+            )
             if not self.can_bid_be_posted(
-                    arguments["energy"],
+                    arguments["energy"] + pending_bid_energy,
                     self.energy_requirement_Wh.get(self.market.time_slot, 0.0) / 1000.0,
                     self.market):
                 self.redis.publish_json(

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -96,8 +96,14 @@ class PVExternalMixin(ExternalMixin):
             arguments['seller'] = self.device.name
             arguments['seller_origin'] = self.device.name
 
+            pending_offer_energy = sum(
+                req.arguments["energy"]
+                for req in self.pending_requests
+                if req.request_type == "offer"
+            )
+
             if not self.can_offer_be_posted(
-                    arguments["energy"],
+                    arguments["energy"] + pending_offer_energy,
                     self.state.available_energy_kWh.get(self.market.time_slot, 0.0),
                     self.market):
                 self.redis.publish_json(

--- a/tests/test_external_mixin.py
+++ b/tests/test_external_mixin.py
@@ -28,6 +28,7 @@ class TestExternalMixin(unittest.TestCase):
     def test_dispatch_tick_frequency_gets_calculated_correctly(self):
         self.external_strategy = LoadHoursExternalStrategy(100)
         self._create_and_activate_strategy_area(self.external_strategy)
+        d3a.models.strategy.external_strategies.DISPATCH_EVENT_TICK_FREQUENCY_PERCENT = 20
         self.config.ticks_per_slot = 90
         assert self.external_strategy._dispatch_tick_frequency == 18
         self.config.ticks_per_slot = 10
@@ -52,6 +53,7 @@ class TestExternalMixin(unittest.TestCase):
         [StorageExternalStrategy()]
     ])
     def test_dispatch_event_tick_to_external_agent(self, strategy):
+        d3a.models.strategy.external_strategies.DISPATCH_EVENT_TICK_FREQUENCY_PERCENT = 20
         self._create_and_activate_strategy_area(strategy)
         self.config.ticks_per_slot = 90
         assert strategy._dispatch_tick_frequency == 18


### PR DESCRIPTION
… the buffered bids and offers, and not only the posted ones, when checking if the required or available energy suffices for posting the new bid/offer.