### PR TITLE
D3ASIM-2742: Unique Areas to be allowed and offer forwarding issue resolved

### DIFF
--- a/src/d3a/d3a_core/sim_results/endpoint_buffer.py
+++ b/src/d3a/d3a_core/sim_results/endpoint_buffer.py
@@ -34,15 +34,7 @@ _NO_VALUE = {
 }
 
 
-def check_duplicates(lst):
-    from collections import Counter
-    dict_data = dict(Counter(lst))
-    return dict_data
-
-
 class SimulationEndpointBuffer:
-    duplicate_list = []
-
     def __init__(self, job_id, initial_params, area, should_export_plots):
         self.job_id = job_id
         self.result_area_uuids = set()
@@ -80,31 +72,12 @@ class SimulationEndpointBuffer:
     @staticmethod
     def _structure_results_from_area_object(target_area):
         area_dict = dict()
-        lst = []
-        if target_area.parent is None:
-            for value in target_area.children:
-                lst.append(value.name)
-            duplicate_values = SimulationEndpointBuffer.get_duplicate_data(lst)
-            SimulationEndpointBuffer.duplicate_list.extend(duplicate_values)
-        if target_area.name in SimulationEndpointBuffer.duplicate_list \
-                and target_area.parent is not None \
-                and target_area.parent.parent is None and target_area.name != 'Market Maker':
-            target_area.rename(target_area.name + target_area.uuid)
-            area_dict['name'] = target_area.name
-        else:
-            area_dict['name'] = target_area.name
+        area_dict['name'] = target_area.name
         area_dict['uuid'] = target_area.uuid
         area_dict['type'] = str(target_area.strategy.__class__.__name__) \
             if target_area.strategy is not None else "Area"
         area_dict['children'] = []
         return area_dict
-
-    @staticmethod
-    def get_duplicate_data(lst):
-        from collections import Counter
-        dict_data = dict(Counter(lst))
-        duplicate_values = [item for item, count in dict_data.items() if count > 1]
-        return duplicate_values
 
     def _create_area_tree_dict(self, area):
         area_result_dict = self._structure_results_from_area_object(area)

--- a/src/d3a/d3a_core/sim_results/endpoint_buffer.py
+++ b/src/d3a/d3a_core/sim_results/endpoint_buffer.py
@@ -72,7 +72,15 @@ class SimulationEndpointBuffer:
     @staticmethod
     def _structure_results_from_area_object(target_area):
         area_dict = dict()
-        area_dict['name'] = target_area.name
+        if target_area.strategy is None and target_area.parent is not None:
+            target_area.rename(target_area.name + target_area.uuid)
+            area_dict['name'] = target_area.name
+        elif (len(target_area.children) == 0) and (target_area.parent is not None) \
+                and target_area.parent.parent is None and target_area.name != 'Market Maker':
+            target_area.rename(target_area.name + target_area.uuid)
+            area_dict['name'] = target_area.name
+        else:
+            area_dict['name'] = target_area.name
         area_dict['uuid'] = target_area.uuid
         area_dict['type'] = str(target_area.strategy.__class__.__name__) \
             if target_area.strategy is not None else "Area"

--- a/src/d3a/d3a_core/sim_results/endpoint_buffer.py
+++ b/src/d3a/d3a_core/sim_results/endpoint_buffer.py
@@ -34,7 +34,15 @@ _NO_VALUE = {
 }
 
 
+def check_duplicates(lst):
+    from collections import Counter
+    dict_data = dict(Counter(lst))
+    return dict_data
+
+
 class SimulationEndpointBuffer:
+    duplicate_list = []
+
     def __init__(self, job_id, initial_params, area, should_export_plots):
         self.job_id = job_id
         self.result_area_uuids = set()
@@ -72,10 +80,14 @@ class SimulationEndpointBuffer:
     @staticmethod
     def _structure_results_from_area_object(target_area):
         area_dict = dict()
-        if target_area.strategy is None and target_area.parent is not None:
-            target_area.rename(target_area.name + target_area.uuid)
-            area_dict['name'] = target_area.name
-        elif (len(target_area.children) == 0) and (target_area.parent is not None) \
+        lst = []
+        if target_area.parent is None:
+            for value in target_area.children:
+                lst.append(value.name)
+            duplicate_values = SimulationEndpointBuffer.get_duplicate_data(lst)
+            SimulationEndpointBuffer.duplicate_list.extend(duplicate_values)
+        if target_area.name in SimulationEndpointBuffer.duplicate_list \
+                and target_area.parent is not None \
                 and target_area.parent.parent is None and target_area.name != 'Market Maker':
             target_area.rename(target_area.name + target_area.uuid)
             area_dict['name'] = target_area.name
@@ -86,6 +98,13 @@ class SimulationEndpointBuffer:
             if target_area.strategy is not None else "Area"
         area_dict['children'] = []
         return area_dict
+
+    @staticmethod
+    def get_duplicate_data(lst):
+        from collections import Counter
+        dict_data = dict(Counter(lst))
+        duplicate_values = [item for item, count in dict_data.items() if count > 1]
+        return duplicate_values
 
     def _create_area_tree_dict(self, area):
         area_result_dict = self._structure_results_from_area_object(area)

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -50,6 +50,8 @@ from d3a.d3a_core.exceptions import D3AException
 from d3a.models.area.event_deserializer import deserialize_events_to_areas
 from d3a.d3a_core.live_events import LiveEvents
 from d3a.d3a_core.sim_results.file_export_endpoints import FileExportEndpoints
+from collections import Counter
+from traceback import print_exc
 
 
 if platform.python_implementation() != "PyPy" and \
@@ -555,8 +557,7 @@ class Simulation:
                     self.rename_area_object(child.children, duplicate_values)
                     self.loop_area_object(child)
         except D3AException as ex:
-            import traceback
-            traceback.print_exc()
+            print_exc()
             raise D3AException("Cannot loop over the area object for renaming", ex)
 
     @staticmethod
@@ -568,12 +569,11 @@ class Simulation:
             pass
 
     @staticmethod
-    def get_duplicate_data(lst):
-        new_lst = []
-        for i in range(len(lst)):
-            new_lst.append(lst[i].name)
-        from collections import Counter
-        dict_data = dict(Counter(new_lst))
+    def get_duplicate_data(children_list):
+        temp_lst = []
+        for num in range(len(children_list)):
+            temp_lst.append(children_list[num].name)
+        dict_data = dict(Counter(temp_lst))
         duplicate_values = [item for item, count in dict_data.items() if count > 1]
         return duplicate_values
 

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -51,7 +51,6 @@ from d3a.models.area.event_deserializer import deserialize_events_to_areas
 from d3a.d3a_core.live_events import LiveEvents
 from d3a.d3a_core.sim_results.file_export_endpoints import FileExportEndpoints
 from collections import Counter
-from traceback import print_exc
 
 
 if platform.python_implementation() != "PyPy" and \
@@ -544,25 +543,16 @@ class Simulation:
         self._load_setup_module()
 
     def loop_area_object(self, target_area):
-        duplicate_values = ""
-        try:
-            if target_area.parent is None:
-                duplicate_values = self.get_duplicate_data(target_area.children)
-                if len(duplicate_values) > 0:
-                    self.rename_area_object(target_area.children, duplicate_values)
+        if len(target_area.children) > 0:
+            duplicate_values = self.get_duplicate_data(target_area.children)
+            if len(duplicate_values) > 0:
+                self.rename_area_object(target_area, duplicate_values)
             for child in target_area.children:
-                if len(child.children) > 0:
-                    duplicate_values = self.get_duplicate_data(child.children)
-                if len(duplicate_values) > 0:
-                    self.rename_area_object(child.children, duplicate_values)
-                    self.loop_area_object(child)
-        except D3AException as ex:
-            print_exc()
-            raise D3AException("Cannot loop over the area object for renaming", ex)
+                self.loop_area_object(child)
 
     @staticmethod
     def rename_area_object(target_area, duplicate_values):
-        for obj in target_area:
+        for obj in target_area.children:
             if obj.name in duplicate_values:
                 obj.rename(obj.name + "_" + obj.uuid)
         else:

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -553,7 +553,7 @@ class Simulation:
             for child in target_area.children:
                 if len(child.children) > 0:
                     duplicate_values = self.get_duplicate_data(child.children)
-                if len(duplicate_values) > 0 and len(child.children) > 0:
+                if len(duplicate_values) > 0:
                     self.rename_area_object(child.children, duplicate_values)
                     self.loop_area_object(child)
         except D3AException as ex:

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -565,9 +565,9 @@ class Simulation:
                 if obj.name in duplicate_values:
                     obj.rename(obj.name + "_" + obj.uuid)
             else:
-                print(":::string value:::", obj.name)
+                pass
         except D3AException as ex:
-            print(ex)
+            raise D3AException("Area object cannot be renamed", ex)
 
     @staticmethod
     def get_duplicate_data(lst):
@@ -579,7 +579,7 @@ class Simulation:
             dict_data = dict(Counter(new_lst))
             duplicate_values = [item for item, count in dict_data.items() if count > 1]
         except D3AException as ex:
-            print(ex)
+            raise D3AException("Error in finding duplicate areas", ex)
         else:
             return duplicate_values
 

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -174,6 +174,7 @@ class Simulation:
 
         self.area = self.setup_module.get_setup(self.simulation_config)
         self.loop_area_object(self.area)
+        log.error(f"Area details after renaming duplicates  {0}: {self.area.child_by_slug}")
         self.endpoint_buffer = SimulationEndpointBuffer(
             redis_job_id, self.initial_params,
             self.area, self.should_export_plots)
@@ -550,7 +551,7 @@ class Simulation:
             for child in target_area.children:
                 if len(child.children) > 0:
                     duplicate_values = self.get_duplicate_data(child.children)
-                if len(duplicate_values) > 0 and len(child.children):
+                if len(duplicate_values) > 0 and len(child.children) > 0:
                     self.rename_area_object(child.children, duplicate_values)
                     self.loop_area_object(child)
         except D3AException as ex:
@@ -560,28 +561,21 @@ class Simulation:
 
     @staticmethod
     def rename_area_object(target_area, duplicate_values):
-        try:
-            for obj in target_area:
-                if obj.name in duplicate_values:
-                    obj.rename(obj.name + "_" + obj.uuid)
-            else:
-                pass
-        except D3AException as ex:
-            raise D3AException("Area object cannot be renamed", ex)
+        for obj in target_area:
+            if obj.name in duplicate_values:
+                obj.rename(obj.name + "_" + obj.uuid)
+        else:
+            pass
 
     @staticmethod
     def get_duplicate_data(lst):
         new_lst = []
-        try:
-            for i in range(len(lst)):
-                new_lst.append(lst[i].name)
-            from collections import Counter
-            dict_data = dict(Counter(new_lst))
-            duplicate_values = [item for item, count in dict_data.items() if count > 1]
-        except D3AException as ex:
-            raise D3AException("Error in finding duplicate areas", ex)
-        else:
-            return duplicate_values
+        for i in range(len(lst)):
+            new_lst.append(lst[i].name)
+        from collections import Counter
+        dict_data = dict(Counter(new_lst))
+        duplicate_values = [item for item, count in dict_data.items() if count > 1]
+        return duplicate_values
 
 
 def run_simulation(setup_module_name="", simulation_config=None, simulation_events=None,

--- a/src/d3a/models/area/__init__.py
+++ b/src/d3a/models/area/__init__.py
@@ -434,3 +434,6 @@ class Area:
             self.strategy.read_config_event()
         for child in self.children:
             child.update_config(**kwargs)
+
+    def rename(self, new_name):
+        self.name = new_name

--- a/src/d3a/models/area/__init__.py
+++ b/src/d3a/models/area/__init__.py
@@ -437,3 +437,4 @@ class Area:
 
     def rename(self, new_name):
         self.name = new_name
+        self.slug = slugify(self.name, to_lower=True)


### PR DESCRIPTION
…here are duplicate names

This PR Fix below Jira numbers

D3ASIM-2740
D3ASIM-2741 - Due to this 2742 change, we need to point some of the plots to respective folders in simulation
D3ASIM-2742
D3ASIM-2739

These changes has impact most of the integration tests, because we have hardcoded the names in many of the integration tests.

I will work on integration tests and also on the and plots movement to respective folders

This PR will be released for review, once other issues resolved.

