### PR TITLE
D3ASIM-3144: Added reading of D3A_MAX_CN_JOBS_PER_POD for CNs.

### DIFF
--- a/src/d3a/d3a_core/launcher.py
+++ b/src/d3a/d3a_core/launcher.py
@@ -25,10 +25,9 @@ from subprocess import Popen
 from time import sleep
 import platform
 from d3a_interface.utils import check_redis_health
-from d3a.d3a_core.util import get_simulation_queue_name
+from d3a.d3a_core.util import get_simulation_queue_name, get_max_jobs_for_launcher
 
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost')
-MAX_JOBS = os.environ.get('D3A_MAX_JOBS_PER_POD', 2)
 
 
 class Launcher:
@@ -38,7 +37,7 @@ class Launcher:
                  max_delay_seconds=2):
         self.queue = queue or Queue(get_simulation_queue_name(), connection=StrictRedis.from_url(
             REDIS_URL, retry_on_timeout=True))
-        self.max_jobs = max_jobs if max_jobs is not None else int(MAX_JOBS)
+        self.max_jobs = max_jobs if max_jobs is not None else get_max_jobs_for_launcher()
         self.max_delay = timedelta(seconds=max_delay_seconds)
         python_executable = sys.executable \
             if platform.python_implementation() != "PyPy" \

--- a/src/d3a/d3a_core/util.py
+++ b/src/d3a/d3a_core/util.py
@@ -583,3 +583,11 @@ def return_ordered_dict(function):
 def get_simulation_queue_name():
     listen_to_cn = os.environ.get("LISTEN_TO_CANARY_NETWORK_REDIS_QUEUE", "no") == "yes"
     return "canary_network" if listen_to_cn else "d3a"
+
+
+def get_max_jobs_for_launcher():
+    listen_to_cn = os.environ.get("LISTEN_TO_CANARY_NETWORK_REDIS_QUEUE", "no") == "yes"
+    if listen_to_cn:
+        return int(os.environ.get('D3A_MAX_CN_JOBS_PER_POD', 50))
+    else:
+        return int(os.environ.get('D3A_MAX_JOBS_PER_POD', 2))


### PR DESCRIPTION
This includes added in the configmap of the d3a-development namespace:
D3A_MAX_CN_JOBS_PER_POD: 50