### PR TITLE
D3ASIM-3206: Fixed conditions to restore a simulation from state. Sho…

### DIFF
--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -622,8 +622,8 @@ def run_simulation(setup_module_name="", simulation_config=None, simulation_even
         raise click.BadOptionUsage(ex.args[0])
 
     if saved_sim_state is not None and \
-        (saved_sim_state["areas"] != {} or
-         saved_sim_state["general"]["sim_status"] != "initializing"):
+        (saved_sim_state["areas"] != {} and
+         saved_sim_state["general"]["sim_status"] in ["running", "paused"]):
         simulation.restore_global_state(saved_sim_state["general"])
         simulation.restore_area_state(saved_sim_state["areas"])
         simulation.run(initial_slot=saved_sim_state["general"]["slot_number"])

--- a/src/d3a/d3a_core/simulation.py
+++ b/src/d3a/d3a_core/simulation.py
@@ -622,8 +622,8 @@ def run_simulation(setup_module_name="", simulation_config=None, simulation_even
         raise click.BadOptionUsage(ex.args[0])
 
     if saved_sim_state is not None and \
-        (saved_sim_state["areas"] != {} and
-         saved_sim_state["general"]["sim_status"] in ["running", "paused"]):
+            saved_sim_state["areas"] != {} and \
+            saved_sim_state["general"]["sim_status"] in ["running", "paused"]:
         simulation.restore_global_state(saved_sim_state["general"])
         simulation.restore_area_state(saved_sim_state["areas"])
         simulation.run(initial_slot=saved_sim_state["general"]["slot_number"])

--- a/src/d3a/models/strategy/predefined_load.py
+++ b/src/d3a/models/strategy/predefined_load.py
@@ -24,6 +24,7 @@ from d3a.models.read_user_profile import read_arbitrary_profile
 from d3a.models.read_user_profile import InputProfileTypes
 from d3a_interface.utils import key_in_dict_and_not_none
 from d3a.d3a_core.util import find_object_of_same_weekday_and_time
+from d3a.d3a_core.exceptions import D3AException
 """
 Create a load that uses a profile as input for its power values
 """
@@ -104,6 +105,10 @@ class DefinedLoadStrategy(LoadHoursStrategy):
         """
         for market in self.area.all_markets:
             slot_time = market.time_slot
+            if not self.load_profile:
+                raise D3AException(
+                    f"Load {self.owner.name} tries to set its energy forecasted requirement "
+                    f"without a profile.")
             load_energy_kWh = \
                 find_object_of_same_weekday_and_time(self.load_profile, slot_time)
             self.state.set_desired_energy(load_energy_kWh * 1000, slot_time, overwrite=False)

--- a/src/d3a/models/strategy/predefined_pv.py
+++ b/src/d3a/models/strategy/predefined_pv.py
@@ -23,6 +23,7 @@ from d3a.models.strategy.pv import PVStrategy
 from d3a_interface.constants_limits import ConstSettings
 from d3a.models.read_user_profile import read_arbitrary_profile, InputProfileTypes
 from d3a_interface.utils import key_in_dict_and_not_none
+from d3a.d3a_core.exceptions import D3AException
 
 """
 Creates a PV that uses a profile as input for its power values, either predefined or provided
@@ -92,6 +93,10 @@ class PVPredefinedStrategy(PVStrategy):
             self._read_predefined_profile_for_pv()
         for market in self.area.all_markets:
             slot_time = market.time_slot
+            if not self.power_profile:
+                raise D3AException(
+                    f"PV {self.owner.name} tries to set its energy forecast without a "
+                    f"power profile.")
             available_energy_kWh = find_object_of_same_weekday_and_time(
                 self.power_profile, slot_time) * self.panel_count
             self.state.set_available_energy(available_energy_kWh, slot_time, reconfigure)


### PR DESCRIPTION
…uld restore only if there are area data, and the simulation status is running or paused. Added explicit exception on the PV strategy in order to capture cases where the PredefinedPV strategy or its subclasses are instantiated without a power profile.