### PR TITLE
D3ASIM-2845 Prevent Duplicate area naming in the same Area

### DIFF
--- a/src/d3a/models/area/__init__.py
+++ b/src/d3a/models/area/__init__.py
@@ -117,7 +117,7 @@ class Area:
         self.uuid = uuid if uuid is not None else str(uuid4())
         self.slug = slugify(name, to_lower=True)
         self.parent = None
-        self.__children = AreaChildrenList(self, children) if children is not None\
+        self.children = AreaChildrenList(self, children) if children is not None\
             else AreaChildrenList(self)
         for child in self.children:
             child.parent = self
@@ -142,18 +142,6 @@ class Area:
         self.redis_ext_conn = RedisMarketExternalConnection(self) \
             if external_connection_available is True else None
         self.should_update_child_strategies = False
-
-    @property
-    def children(self):
-        return self.__children
-
-    @children.setter
-    def children(self, new_children: AreaChildrenList):
-        if type(new_children) == list:
-            self.__children = AreaChildrenList(self, new_children)
-        elif type(new_children) == AreaChildrenList:
-            new_children.parent_area = self
-            self.__children = new_children
 
     @property
     def name(self):

--- a/src/d3a/models/area/__init__.py
+++ b/src/d3a/models/area/__init__.py
@@ -59,6 +59,39 @@ DEFAULT_CONFIG = SimulationConfig(
 )
 
 
+def check_area_name_exists_in_parent_area(parent_area, name):
+    """
+    Check the children of parent of area , iterate through its children and
+        check if the name to be appended does not exist
+    Note: this check is to be called before adding a new area of changing its name
+    :param parent_area: Parent Area
+    :param name: New name of area
+    :return: boolean
+    """
+    for child in parent_area.children:
+        if child.name == name:
+            return True
+    return False
+
+
+class AreaChildrenList(list):
+    def __init__(self, parent_area, *args, **kwargs):
+        self.parent_area = parent_area
+        super(AreaChildrenList, self).__init__(*args, **kwargs)
+
+    def _validate_before_insertion(self, item):
+        if check_area_name_exists_in_parent_area(self.parent_area, item.name):
+            raise AreaException("Area name should be unique inside the same Parent Area")
+
+    def append(self, item: "Area") -> None:
+        self._validate_before_insertion(item)
+        super(AreaChildrenList, self).append(item)
+
+    def insert(self, index, item):
+        self._validate_before_insertion(item)
+        super(AreaChildrenList, self).insert(index, item)
+
+
 class Area:
 
     def __init__(self, name: str = None, children: List["Area"] = None,
@@ -79,12 +112,13 @@ class Area:
         self.active = False
         self.log = TaggedLogWrapper(log, name)
         self.current_tick = 0
-        self.name = name
+        self.__name = name
         self.throughput = throughput
         self.uuid = uuid if uuid is not None else str(uuid4())
         self.slug = slugify(name, to_lower=True)
         self.parent = None
-        self.children = children if children is not None else []
+        self.__children = AreaChildrenList(self, children) if children is not None\
+            else AreaChildrenList(self)
         for child in self.children:
             child.parent = self
 
@@ -108,6 +142,29 @@ class Area:
         self.redis_ext_conn = RedisMarketExternalConnection(self) \
             if external_connection_available is True else None
         self.should_update_child_strategies = False
+
+    @property
+    def children(self):
+        return self.__children
+
+    @children.setter
+    def children(self, new_children: AreaChildrenList):
+        if type(new_children) == list:
+            self.__children = AreaChildrenList(self, new_children)
+        elif type(new_children) == AreaChildrenList:
+            new_children.parent_area = self
+            self.__children = new_children
+
+    @property
+    def name(self):
+        return self.__name
+
+    @name.setter
+    def name(self, new_name):
+        if not check_area_name_exists_in_parent_area(self.parent, new_name):
+            self.__name = new_name
+        else:
+            raise AreaException("Area name should be unique inside the same Parent Area")
 
     def get_state(self):
         state = {}

--- a/src/d3a/models/area/__init__.py
+++ b/src/d3a/models/area/__init__.py
@@ -61,7 +61,7 @@ DEFAULT_CONFIG = SimulationConfig(
 
 def check_area_name_exists_in_parent_area(parent_area, name):
     """
-    Check the children of parent of area , iterate through its children and
+    Check the children of parent area , iterate through its children and
         check if the name to be appended does not exist
     Note: this check is to be called before adding a new area of changing its name
     :param parent_area: Parent Area


### PR DESCRIPTION
### Description
This is part 2 of the restriction to have duplicate area names inside the same parent area
### References
[D3A web side](https://github.com/gridsingularity/d3a-web/pull/1122)