### PR TITLE
D3ASIM-3206: Omitted setting demanded or produced energy profile for …

### DIFF
--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -437,7 +437,9 @@ class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
         energy_forecast_Wh = self.energy_forecast_buffer_Wh
         slot_time = self.area.next_market.time_slot
         self.state.set_desired_energy(energy_forecast_Wh, slot_time, overwrite=True)
-        self.state.update_total_demanded_energy(slot_time)
+        # TODO: Check self-sufficiency / self-consumption of LoadForecastExternalStrategy and
+        #  and consider re-adding:
+        # self.state.update_total_demanded_energy(slot_time)
 
     def _update_energy_requirement_future_markets(self):
         """

--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -437,3 +437,10 @@ class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
         energy_forecast_Wh = self.energy_forecast_buffer_Wh
         slot_time = self.area.next_market.time_slot
         self.state.set_desired_energy(energy_forecast_Wh, slot_time, overwrite=True)
+        self.state.update_total_demanded_energy(slot_time)
+
+    def _update_energy_requirement_future_markets(self):
+        """
+        Setting demanded energy for the next slot is already done by update_energy_forecast
+        """
+        pass

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -444,3 +444,9 @@ class PVForecastExternalStrategy(PVPredefinedExternalStrategy):
 
         slot_time = self.area.next_market.time_slot
         self.state.set_available_energy(energy_forecast_kWh, slot_time, overwrite=True)
+
+    def set_produced_energy_forecast_kWh_future_markets(self):
+        """
+        Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
+        """
+        pass

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -445,7 +445,7 @@ class PVForecastExternalStrategy(PVPredefinedExternalStrategy):
         slot_time = self.area.next_market.time_slot
         self.state.set_available_energy(energy_forecast_kWh, slot_time, overwrite=True)
 
-    def set_produced_energy_forecast_kWh_future_markets(self):
+    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False):
         """
         Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
         """


### PR DESCRIPTION
…live data PV and Load in market_cycle, because this is done already by seperate endpoint.

Traceback:
```

Jan 15, 2021 @ 15:25:00.017 | Error on jobId 931c1d72-88d9-46cd-8fdf-0753d555bd8d: Traceback (most recent call last):
-- | --

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/d3a_core/d3a_jobs.py", line 144, in start

  | Jan 15, 2021 @ 15:25:00.017 | kwargs=kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/d3a_core/simulation.py", line 631, in run_simulation

  | Jan 15, 2021 @ 15:25:00.017 | simulation.run()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/d3a_core/simulation.py", line 237, in run

  | Jan 15, 2021 @ 15:25:00.017 | else self._execute_simulation(initial_slot, tick_resume)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/d3a_core/simulation.py", line 346, in _execute_simulation

  | Jan 15, 2021 @ 15:25:00.017 | self.area.cycle_markets()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/__init__.py", line 310, in cycle_markets

  | Jan 15, 2021 @ 15:25:00.017 | self.dispatcher.broadcast_market_cycle()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 66, in broadcast_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | return self._broadcast_notification(AreaEvent.MARKET_CYCLE, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 81, in _broadcast_notification

  | Jan 15, 2021 @ 15:25:00.017 | child.dispatcher.event_listener(event_type, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 115, in event_listener

  | Jan 15, 2021 @ 15:25:00.017 | self.area.cycle_markets(_trigger_event=True)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/__init__.py", line 310, in cycle_markets

  | Jan 15, 2021 @ 15:25:00.017 | self.dispatcher.broadcast_market_cycle()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 66, in broadcast_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | return self._broadcast_notification(AreaEvent.MARKET_CYCLE, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 81, in _broadcast_notification

  | Jan 15, 2021 @ 15:25:00.017 | child.dispatcher.event_listener(event_type, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 115, in event_listener

  | Jan 15, 2021 @ 15:25:00.017 | self.area.cycle_markets(_trigger_event=True)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/__init__.py", line 310, in cycle_markets

  | Jan 15, 2021 @ 15:25:00.017 | self.dispatcher.broadcast_market_cycle()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 66, in broadcast_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | return self._broadcast_notification(AreaEvent.MARKET_CYCLE, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 81, in _broadcast_notification

  | Jan 15, 2021 @ 15:25:00.017 | child.dispatcher.event_listener(event_type, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/area/event_dispatcher.py", line 120, in event_listener

  | Jan 15, 2021 @ 15:25:00.017 | self.area.strategy.event_listener(event_type, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/strategy/__init__.py", line 402, in event_listener

  | Jan 15, 2021 @ 15:25:00.017 | super().event_listener(event_type, **kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/events/__init__.py", line 58, in event_listener

  | Jan 15, 2021 @ 15:25:00.017 | self._event_mapping(event_type)(**kwargs)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/strategy/external_strategies/pv.py", line 436, in event_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | super().event_market_cycle()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/strategy/external_strategies/pv.py", line 208, in event_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | super().event_market_cycle()

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/strategy/pv.py", line 230, in event_market_cycle

  | Jan 15, 2021 @ 15:25:00.017 | self.set_produced_energy_forecast_kWh_future_markets(reconfigure=False)

  | Jan 15, 2021 @ 15:25:00.017 | File "/app/src/d3a/models/strategy/predefined_pv.py", line 98, in set_produced_energy_forecast_kWh_future_markets

  | Jan 15, 2021 @ 15:25:00.017 | f"PV {self.owner.name} tries to set its energy forecast without a "

  | Jan 15, 2021 @ 15:25:00.017 | d3a_interface.exceptions.D3AException: PV OLI_24 tries to set its energy forecast without a power profile.


```