### PR TITLE
added_pytz_to_requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,4 +13,5 @@ plotly
 python-rex
 redis
 rq
+pytz
 sortedcontainers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,7 @@ pip-tools==5.4.0          # via -r requirements/base.in
 plotly==4.14.1            # via -r requirements/base.in
 python-dateutil==2.8.1    # via pendulum
 python-rex==0.4           # via -r requirements/base.in
+pytz==2020.4              # via -r requirements/base.in
 pytzdata==2020.1          # via pendulum
 redis==3.5.3              # via -r requirements/base.in, rq
 regex==2020.11.13         # via awesome-slugify

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ pip-tools==5.4.0          # via -r requirements/base.in
 plotly==4.14.1            # via -r requirements/base.in
 python-dateutil==2.8.1    # via pendulum
 python-rex==0.4           # via -r requirements/base.in
-pytz==2020.4              # via -r requirements/base.in
+pytz==2020.5              # via -r requirements/base.in
 pytzdata==2020.1          # via pendulum
 redis==3.5.3              # via -r requirements/base.in, rq
 regex==2020.11.13         # via awesome-slugify

--- a/requirements/pandapower.txt
+++ b/requirements/pandapower.txt
@@ -19,7 +19,7 @@ pillow==8.0.1             # via matplotlib
 pycparser==2.20           # via cffi
 pyparsing==2.4.7          # via matplotlib, packaging
 python-dateutil==2.8.1    # via matplotlib, pandas
-pytz==2020.4              # via pandas
+pytz==2020.5              # via pandas
 scipy==1.5.4              # via pandapower
 six==1.15.0               # via cryptography, cycler, python-dateutil
 xlrd==1.2.0               # via pandapower


### PR DESCRIPTION
This is needed to deserialize timezone aware timestamps send by the d3a-web.