### PR TITLE
Update pre-commit hooks generation and remove warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       args: ['--remove']
     - id: trailing-whitespace
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.4
     hooks:
     - id: flake8
       additional_dependencies: ["flake8-tuple"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.7.1
+    rev: v3.4.0
     hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -10,6 +11,9 @@
     - id: end-of-file-fixer
     - id: fix-encoding-pragma
       args: ['--remove']
+    - id: trailing-whitespace
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.1
+    hooks:
     - id: flake8
       additional_dependencies: ["flake8-tuple"]
-    - id: trailing-whitespace


### PR DESCRIPTION
# Content

- Update `.pre-commit-config.yaml` to point to the latest version (3.4.0) of [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks)
- Replace `flake8` as recommended in the [release notes of pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v3.0.0)

# Rationale

D3A uses `pre-commit-hooks` along with the config file `.pre-commit-config.yaml` to set up git's pre-commit hooks.

Our `pre-commit-config.yaml` file is quite outdated, so we have warnings like the following:
```
[WARNING] normalizing pre-commit configuration to a top-level map.  support for top level list will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] Unexpected key(s) present on git://github.com/pre-commit/pre-commit-hooks: sha
```

Upgrading to the latest version fixes the warnings. Flake8 has been removed from pre-commit-hooks, so we also need to point this hook to a separate repository.