### PR TITLE
D3ASIM-3302: Added to state the information whether an API client was…

### DIFF
--- a/src/d3a/models/strategy/external_strategies/__init__.py
+++ b/src/d3a/models/strategy/external_strategies/__init__.py
@@ -92,6 +92,20 @@ class ExternalMixin:
         self.pending_requests = []
         self.lock = Lock()
 
+    def get_state(self):
+        strategy_state = super().get_state()
+        strategy_state.update({
+            "connected": self.connected,
+            "use_template_strategy": self._use_template_strategy
+        })
+        return strategy_state
+
+    def restore_state(self, state_dict):
+        super().restore_state(state_dict)
+        self._connected = state_dict.get("connected", False)
+        self.connected = state_dict.get("connected", False)
+        self._use_template_strategy = state_dict.get("use_template_strategy", False)
+
     @property
     def channel_dict(self):
         return {


### PR DESCRIPTION
… already connected to a specific area. Also saved information about whether to use the template strategy or the external strategy.