### PR TITLE
Fix dependencies between requirements environments

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,3 @@
-pip==20.3.1
 attrs
 awesome-slugify
 base58

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,29 +4,63 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/base.in
 #
-attrs==20.3.0             # via -r requirements/base.in
-awesome-slugify==1.6.5    # via -r requirements/base.in
-base58==2.1.0             # via -r requirements/base.in
-cached-property==1.5.2    # via -r requirements/base.in
-click-default-group==1.2.2  # via -r requirements/base.in
-click==7.1.2              # via -r requirements/base.in, click-default-group, pip-tools, rq
-colorlog==4.7.2           # via -r requirements/base.in
-numpy==1.19.4             # via -r requirements/base.in
-pendulum==2.1.2           # via -r requirements/base.in
-pip-tools==5.4.0          # via -r requirements/base.in
-plotly==4.14.1            # via -r requirements/base.in
-python-dateutil==2.8.1    # via pendulum
-python-rex==0.4           # via -r requirements/base.in
-pytz==2020.5              # via -r requirements/base.in
-pytzdata==2020.1          # via pendulum
-redis==3.5.3              # via -r requirements/base.in, rq
-regex==2020.11.13         # via awesome-slugify
-retrying==1.3.3           # via plotly
-rq==1.7.0                 # via -r requirements/base.in
-six==1.15.0               # via pip-tools, plotly, python-dateutil, python-rex, retrying
-sortedcontainers==2.3.0   # via -r requirements/base.in
-unidecode==0.4.21         # via awesome-slugify
-urllib3==1.26.3           # via -r requirements/base.in
+attrs==20.3.0
+    # via -r requirements/base.in
+awesome-slugify==1.6.5
+    # via -r requirements/base.in
+base58==2.1.0
+    # via -r requirements/base.in
+cached-property==1.5.2
+    # via -r requirements/base.in
+click-default-group==1.2.2
+    # via -r requirements/base.in
+click==7.1.2
+    # via
+    #   -r requirements/base.in
+    #   click-default-group
+    #   pip-tools
+    #   rq
+colorlog==4.7.2
+    # via -r requirements/base.in
+numpy==1.19.4
+    # via -r requirements/base.in
+pendulum==2.1.2
+    # via -r requirements/base.in
+pip-tools==5.4.0
+    # via -r requirements/base.in
+plotly==4.14.1
+    # via -r requirements/base.in
+python-dateutil==2.8.1
+    # via pendulum
+python-rex==0.4
+    # via -r requirements/base.in
+pytz==2020.5
+    # via -r requirements/base.in
+pytzdata==2020.1
+    # via pendulum
+redis==3.5.3
+    # via
+    #   -r requirements/base.in
+    #   rq
+regex==2020.11.13
+    # via awesome-slugify
+retrying==1.3.3
+    # via plotly
+rq==1.7.0
+    # via -r requirements/base.in
+six==1.15.0
+    # via
+    #   pip-tools
+    #   plotly
+    #   python-dateutil
+    #   python-rex
+    #   retrying
+sortedcontainers==2.3.0
+    # via -r requirements/base.in
+unidecode==0.4.21
+    # via awesome-slugify
+urllib3==1.26.3
+    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/blockchain.txt
+++ b/requirements/blockchain.txt
@@ -4,41 +4,110 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/blockchain.in
 #
-attrs==20.3.0             # via -r requirements/base.txt
-awesome-slugify==1.6.5    # via -r requirements/base.txt
-base58==2.1.0             # via -r requirements/base.txt, scalecodec, substrate-interface
-cached-property==1.5.2    # via -r requirements/base.txt
-certifi==2020.12.5        # via requests, substrate-interface
-chardet==4.0.0            # via requests
-click-default-group==1.2.2  # via -r requirements/base.txt
-click==7.1.2              # via -r requirements/base.txt, click-default-group, pip-tools, rq
-colorlog==4.7.2           # via -r requirements/base.txt
-idna==2.10                # via requests, substrate-interface
-more-itertools==8.7.0     # via scalecodec
-numpy==1.19.4             # via -r requirements/base.txt
-pendulum==2.1.2           # via -r requirements/base.txt
-pip-tools==5.4.0          # via -r requirements/base.txt
-plotly==4.14.1            # via -r requirements/base.txt
-py-bip39-bindings==0.1.6  # via substrate-interface
-py-ed25519-bindings==0.1.2  # via substrate-interface
-py-sr25519-bindings==0.1.2  # via substrate-interface
-python-dateutil==2.8.1    # via -r requirements/base.txt, pendulum
-python-rex==0.4           # via -r requirements/base.txt
-pytz==2020.5              # via -r requirements/base.txt
-pytzdata==2020.1          # via -r requirements/base.txt, pendulum
-redis==3.5.3              # via -r requirements/base.txt, rq
-regex==2020.11.13         # via -r requirements/base.txt, awesome-slugify
-requests==2.25.1          # via scalecodec, substrate-interface
-retrying==1.3.3           # via -r requirements/base.txt, plotly
-rq==1.7.0                 # via -r requirements/base.txt
-scalecodec==0.10.54       # via substrate-interface
-six==1.15.0               # via -r requirements/base.txt, pip-tools, plotly, python-dateutil, python-rex, retrying, websocket-client
-sortedcontainers==2.3.0   # via -r requirements/base.txt
-substrate-interface==0.11.15  # via -r requirements/blockchain.in
-unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
-urllib3==1.26.3           # via -r requirements/base.txt, requests
-websocket-client==0.57.0  # via substrate-interface
-xxhash==2.0.0             # via substrate-interface
+attrs==20.3.0
+    # via -r requirements/base.txt
+awesome-slugify==1.6.5
+    # via -r requirements/base.txt
+base58==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   scalecodec
+    #   substrate-interface
+cached-property==1.5.2
+    # via -r requirements/base.txt
+certifi==2020.12.5
+    # via
+    #   requests
+    #   substrate-interface
+chardet==4.0.0
+    # via requests
+click-default-group==1.2.2
+    # via -r requirements/base.txt
+click==7.1.2
+    # via
+    #   -r requirements/base.txt
+    #   click-default-group
+    #   pip-tools
+    #   rq
+colorlog==4.7.2
+    # via -r requirements/base.txt
+idna==2.10
+    # via
+    #   requests
+    #   substrate-interface
+more-itertools==8.7.0
+    # via scalecodec
+numpy==1.19.4
+    # via -r requirements/base.txt
+pendulum==2.1.2
+    # via -r requirements/base.txt
+pip-tools==5.4.0
+    # via -r requirements/base.txt
+plotly==4.14.1
+    # via -r requirements/base.txt
+py-bip39-bindings==0.1.6
+    # via substrate-interface
+py-ed25519-bindings==0.1.2
+    # via substrate-interface
+py-sr25519-bindings==0.1.2
+    # via substrate-interface
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   pendulum
+python-rex==0.4
+    # via -r requirements/base.txt
+pytz==2020.5
+    # via -r requirements/base.txt
+pytzdata==2020.1
+    # via
+    #   -r requirements/base.txt
+    #   pendulum
+redis==3.5.3
+    # via
+    #   -r requirements/base.txt
+    #   rq
+regex==2020.11.13
+    # via
+    #   -r requirements/base.txt
+    #   awesome-slugify
+requests==2.25.1
+    # via
+    #   scalecodec
+    #   substrate-interface
+retrying==1.3.3
+    # via
+    #   -r requirements/base.txt
+    #   plotly
+rq==1.7.0
+    # via -r requirements/base.txt
+scalecodec==0.10.54
+    # via substrate-interface
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   pip-tools
+    #   plotly
+    #   python-dateutil
+    #   python-rex
+    #   retrying
+    #   websocket-client
+sortedcontainers==2.3.0
+    # via -r requirements/base.txt
+substrate-interface==0.11.15
+    # via -r requirements/blockchain.in
+unidecode==0.4.21
+    # via
+    #   -r requirements/base.txt
+    #   awesome-slugify
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+websocket-client==0.57.0
+    # via substrate-interface
+xxhash==2.0.0
+    # via substrate-interface
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,5 @@
 -r base.txt
+
 fabric3
 pre-commit
 psutil

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,58 +4,151 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/dev.in
 #
-appdirs==1.4.4            # via ptpython, virtualenv
-attrs==20.3.0             # via -r requirements/base.txt
-awesome-slugify==1.6.5    # via -r requirements/base.txt
-base58==2.1.0             # via -r requirements/base.txt
-bcrypt==3.2.0             # via paramiko
-cached-property==1.5.2    # via -r requirements/base.txt
-cffi==1.14.4              # via bcrypt, cryptography, pynacl
-cfgv==3.2.0               # via pre-commit
-click-default-group==1.2.2  # via -r requirements/base.txt
-click==7.1.2              # via -r requirements/base.txt, click-default-group, pip-tools, rq
-colorlog==4.7.2           # via -r requirements/base.txt
-cryptography==3.3.1       # via paramiko
-distlib==0.3.1            # via virtualenv
-fabric3==1.14.post1       # via -r requirements/dev.in
-filelock==3.0.12          # via tox, virtualenv
-identify==1.5.10          # via pre-commit
-jedi==0.17.2              # via ptpython
-nodeenv==1.5.0            # via pre-commit
-numpy==1.19.4             # via -r requirements/base.txt
-packaging==20.7           # via tox
-paramiko==2.7.2           # via fabric3
-parso==0.7.1              # via jedi
-pendulum==2.1.2           # via -r requirements/base.txt
-pip-tools==5.4.0          # via -r requirements/base.txt
-plotly==4.14.1            # via -r requirements/base.txt
-pluggy==0.13.1            # via tox
-pre-commit==2.9.3         # via -r requirements/dev.in
-prompt-toolkit==3.0.8     # via ptpython
-psutil==5.7.3             # via -r requirements/dev.in
-ptpython==3.0.7           # via -r requirements/dev.in
-py==1.9.0                 # via tox
-pycparser==2.20           # via cffi
-pygments==2.8.1           # via ptpython
-pynacl==1.4.0             # via paramiko
-pyparsing==2.4.7          # via packaging
-python-dateutil==2.8.1    # via -r requirements/base.txt, pendulum
-python-rex==0.4           # via -r requirements/base.txt
-pytz==2020.5              # via -r requirements/base.txt
-pytzdata==2020.1          # via -r requirements/base.txt, pendulum
-pyyaml==5.3.1             # via -r requirements/dev.in, pre-commit
-redis==3.5.3              # via -r requirements/base.txt, rq
-regex==2020.11.13         # via -r requirements/base.txt, awesome-slugify
-retrying==1.3.3           # via -r requirements/base.txt, plotly
-rq==1.7.0                 # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, bcrypt, cryptography, fabric3, pip-tools, plotly, pynacl, python-dateutil, python-rex, retrying, tox, virtualenv
-sortedcontainers==2.3.0   # via -r requirements/base.txt
-toml==0.10.2              # via pre-commit, tox
-tox==3.20.1               # via -r requirements/dev.in
-unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
-urllib3==1.26.3           # via -r requirements/base.txt
-virtualenv==20.2.2        # via pre-commit, tox
-wcwidth==0.2.5            # via prompt-toolkit
+appdirs==1.4.4
+    # via
+    #   ptpython
+    #   virtualenv
+attrs==20.3.0
+    # via -r requirements/base.txt
+awesome-slugify==1.6.5
+    # via -r requirements/base.txt
+base58==2.1.0
+    # via -r requirements/base.txt
+bcrypt==3.2.0
+    # via paramiko
+cached-property==1.5.2
+    # via -r requirements/base.txt
+cffi==1.14.4
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+cfgv==3.2.0
+    # via pre-commit
+click-default-group==1.2.2
+    # via -r requirements/base.txt
+click==7.1.2
+    # via
+    #   -r requirements/base.txt
+    #   click-default-group
+    #   pip-tools
+    #   rq
+colorlog==4.7.2
+    # via -r requirements/base.txt
+cryptography==3.3.1
+    # via paramiko
+distlib==0.3.1
+    # via virtualenv
+fabric3==1.14.post1
+    # via -r requirements/dev.in
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+identify==1.5.10
+    # via pre-commit
+jedi==0.17.2
+    # via ptpython
+nodeenv==1.5.0
+    # via pre-commit
+numpy==1.19.4
+    # via -r requirements/base.txt
+packaging==20.7
+    # via tox
+paramiko==2.7.2
+    # via fabric3
+parso==0.7.1
+    # via jedi
+pendulum==2.1.2
+    # via -r requirements/base.txt
+pip-tools==5.4.0
+    # via -r requirements/base.txt
+plotly==4.14.1
+    # via -r requirements/base.txt
+pluggy==0.13.1
+    # via tox
+pre-commit==2.9.3
+    # via -r requirements/dev.in
+prompt-toolkit==3.0.8
+    # via ptpython
+psutil==5.7.3
+    # via -r requirements/dev.in
+ptpython==3.0.7
+    # via -r requirements/dev.in
+py==1.9.0
+    # via tox
+pycparser==2.20
+    # via cffi
+pygments==2.8.1
+    # via ptpython
+pynacl==1.4.0
+    # via paramiko
+pyparsing==2.4.7
+    # via packaging
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   pendulum
+python-rex==0.4
+    # via -r requirements/base.txt
+pytz==2020.5
+    # via -r requirements/base.txt
+pytzdata==2020.1
+    # via
+    #   -r requirements/base.txt
+    #   pendulum
+pyyaml==5.3.1
+    # via
+    #   -r requirements/dev.in
+    #   pre-commit
+redis==3.5.3
+    # via
+    #   -r requirements/base.txt
+    #   rq
+regex==2020.11.13
+    # via
+    #   -r requirements/base.txt
+    #   awesome-slugify
+retrying==1.3.3
+    # via
+    #   -r requirements/base.txt
+    #   plotly
+rq==1.7.0
+    # via -r requirements/base.txt
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   bcrypt
+    #   cryptography
+    #   fabric3
+    #   pip-tools
+    #   plotly
+    #   pynacl
+    #   python-dateutil
+    #   python-rex
+    #   retrying
+    #   tox
+    #   virtualenv
+sortedcontainers==2.3.0
+    # via -r requirements/base.txt
+toml==0.10.2
+    # via
+    #   pre-commit
+    #   tox
+tox==3.20.1
+    # via -r requirements/dev.in
+unidecode==0.4.21
+    # via
+    #   -r requirements/base.txt
+    #   awesome-slugify
+urllib3==1.26.3
+    # via -r requirements/base.txt
+virtualenv==20.2.2
+    # via
+    #   pre-commit
+    #   tox
+wcwidth==0.2.5
+    # via prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pandapower.in
+++ b/requirements/pandapower.in
@@ -1,2 +1,4 @@
+-r dev.txt
+
 pandapower
 matplotlib==3.4.0

--- a/requirements/pandapower.txt
+++ b/requirements/pandapower.txt
@@ -4,23 +4,227 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/pandapower.in
 #
-cffi==1.14.4              # via cryptography
-cryptography==3.4.7       # via pandapower
-cycler==0.10.0            # via matplotlib
-decorator==4.4.2          # via networkx
-kiwisolver==1.3.1         # via matplotlib
-matplotlib==3.4.0         # via -r requirements/pandapower.in
-networkx==2.5             # via pandapower
-numpy==1.19.4             # via matplotlib, pandapower, pandas, scipy
-packaging==20.7           # via pandapower
-pandapower==2.4.0         # via -r requirements/pandapower.in
-pandas==1.1.5             # via pandapower
-pillow==8.1.2             # via matplotlib
-pycparser==2.20           # via cffi
-pyparsing==2.4.7          # via matplotlib, packaging
-python-dateutil==2.8.1    # via matplotlib, pandas
-pytz==2020.5              # via pandas
-scipy==1.5.4              # via pandapower
-six==1.15.0               # via cycler, python-dateutil
-xlrd==1.2.0               # via pandapower
-xlsxwriter==1.3.7         # via pandapower
+appdirs==1.4.4
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+    #   virtualenv
+attrs==20.3.0
+    # via -r requirements/dev.txt
+awesome-slugify==1.6.5
+    # via -r requirements/dev.txt
+base58==2.1.0
+    # via -r requirements/dev.txt
+bcrypt==3.2.0
+    # via
+    #   -r requirements/dev.txt
+    #   paramiko
+cached-property==1.5.2
+    # via -r requirements/dev.txt
+cffi==1.14.4
+    # via
+    #   -r requirements/dev.txt
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+cfgv==3.2.0
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+click-default-group==1.2.2
+    # via -r requirements/dev.txt
+click==7.1.2
+    # via
+    #   -r requirements/dev.txt
+    #   click-default-group
+    #   pip-tools
+    #   rq
+colorlog==4.7.2
+    # via -r requirements/dev.txt
+cryptography==3.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   pandapower
+    #   paramiko
+cycler==0.10.0
+    # via matplotlib
+decorator==4.4.2
+    # via networkx
+distlib==0.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   virtualenv
+fabric3==1.14.post1
+    # via -r requirements/dev.txt
+filelock==3.0.12
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+    #   virtualenv
+identify==1.5.10
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+jedi==0.17.2
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+kiwisolver==1.3.1
+    # via matplotlib
+matplotlib==3.4.0
+    # via -r requirements/pandapower.in
+networkx==2.5
+    # via pandapower
+nodeenv==1.5.0
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+numpy==1.19.4
+    # via
+    #   -r requirements/dev.txt
+    #   matplotlib
+    #   pandapower
+    #   pandas
+    #   scipy
+packaging==20.7
+    # via
+    #   -r requirements/dev.txt
+    #   pandapower
+    #   tox
+pandapower==2.4.0
+    # via -r requirements/pandapower.in
+pandas==1.1.5
+    # via pandapower
+paramiko==2.7.2
+    # via
+    #   -r requirements/dev.txt
+    #   fabric3
+parso==0.7.1
+    # via
+    #   -r requirements/dev.txt
+    #   jedi
+pendulum==2.1.2
+    # via -r requirements/dev.txt
+pillow==8.1.2
+    # via matplotlib
+pip-tools==5.4.0
+    # via -r requirements/dev.txt
+plotly==4.14.1
+    # via -r requirements/dev.txt
+pluggy==0.13.1
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+pre-commit==2.9.3
+    # via -r requirements/dev.txt
+prompt-toolkit==3.0.8
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+psutil==5.7.3
+    # via -r requirements/dev.txt
+ptpython==3.0.7
+    # via -r requirements/dev.txt
+py==1.9.0
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+pycparser==2.20
+    # via
+    #   -r requirements/dev.txt
+    #   cffi
+pygments==2.8.1
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+pynacl==1.4.0
+    # via
+    #   -r requirements/dev.txt
+    #   paramiko
+pyparsing==2.4.7
+    # via
+    #   -r requirements/dev.txt
+    #   matplotlib
+    #   packaging
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/dev.txt
+    #   matplotlib
+    #   pandas
+    #   pendulum
+python-rex==0.4
+    # via -r requirements/dev.txt
+pytz==2020.5
+    # via
+    #   -r requirements/dev.txt
+    #   pandas
+pytzdata==2020.1
+    # via
+    #   -r requirements/dev.txt
+    #   pendulum
+pyyaml==5.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+redis==3.5.3
+    # via
+    #   -r requirements/dev.txt
+    #   rq
+regex==2020.11.13
+    # via
+    #   -r requirements/dev.txt
+    #   awesome-slugify
+retrying==1.3.3
+    # via
+    #   -r requirements/dev.txt
+    #   plotly
+rq==1.7.0
+    # via -r requirements/dev.txt
+scipy==1.5.4
+    # via pandapower
+six==1.15.0
+    # via
+    #   -r requirements/dev.txt
+    #   bcrypt
+    #   cryptography
+    #   cycler
+    #   fabric3
+    #   pip-tools
+    #   plotly
+    #   pynacl
+    #   python-dateutil
+    #   python-rex
+    #   retrying
+    #   tox
+    #   virtualenv
+sortedcontainers==2.3.0
+    # via -r requirements/dev.txt
+toml==0.10.2
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+    #   tox
+tox==3.20.1
+    # via -r requirements/dev.txt
+unidecode==0.4.21
+    # via
+    #   -r requirements/dev.txt
+    #   awesome-slugify
+urllib3==1.26.3
+    # via -r requirements/dev.txt
+virtualenv==20.2.2
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+    #   tox
+wcwidth==0.2.5
+    # via
+    #   -r requirements/dev.txt
+    #   prompt-toolkit
+xlrd==1.2.0
+    # via pandapower
+xlsxwriter==1.3.7
+    # via pandapower
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,13 +1,12 @@
--r base.txt
+-r dev.txt
 
 behave
 coverage
-flake8==3.7.9
+deepdiff
 flake8-tuple
+flake8==3.7.9
 hypothesis==4.38.0
 isort
 parameterized
 pytest
-ptpython
 requests-mock
-deepdiff

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,63 +4,253 @@
 #
 #    pip-compile --max-rounds=100 --no-emit-index-url requirements/tests.in
 #
-appdirs==1.4.4            # via ptpython
-attrs==20.3.0             # via -r requirements/base.txt, hypothesis, pytest
-awesome-slugify==1.6.5    # via -r requirements/base.txt
-base58==2.1.0             # via -r requirements/base.txt
-behave==1.2.6             # via -r requirements/tests.in
-cached-property==1.5.2    # via -r requirements/base.txt
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-click-default-group==1.2.2  # via -r requirements/base.txt
-click==7.1.2              # via -r requirements/base.txt, click-default-group, pip-tools, rq
-colorlog==4.7.2           # via -r requirements/base.txt
-coverage==5.3             # via -r requirements/tests.in
-deepdiff==5.0.2           # via -r requirements/tests.in
-entrypoints==0.3          # via flake8
-flake8-tuple==0.4.1       # via -r requirements/tests.in
-flake8==3.7.9             # via -r requirements/tests.in, flake8-tuple
-hypothesis==4.38.0        # via -r requirements/tests.in
-idna==2.10                # via requests
-iniconfig==1.1.1          # via pytest
-isort==5.6.4              # via -r requirements/tests.in
-jedi==0.17.2              # via ptpython
-mccabe==0.6.1             # via flake8
-numpy==1.19.4             # via -r requirements/base.txt
-ordered-set==4.0.2        # via deepdiff
-packaging==20.7           # via pytest
-parameterized==0.7.4      # via -r requirements/tests.in
-parse-type==0.5.2         # via behave
-parse==1.18.0             # via behave, parse-type
-parso==0.7.1              # via jedi
-pendulum==2.1.2           # via -r requirements/base.txt
-pip-tools==5.4.0          # via -r requirements/base.txt
-plotly==4.14.1            # via -r requirements/base.txt
-pluggy==0.13.1            # via pytest
-prompt-toolkit==3.0.8     # via ptpython
-ptpython==3.0.7           # via -r requirements/tests.in
-py==1.9.0                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pygments==2.7.3           # via ptpython
-pyparsing==2.4.7          # via packaging
-pytest==6.1.2             # via -r requirements/tests.in
-python-dateutil==2.8.1    # via -r requirements/base.txt, pendulum
-python-rex==0.4           # via -r requirements/base.txt
-pytz==2020.5              # via -r requirements/base.txt
-pytzdata==2020.1          # via -r requirements/base.txt, pendulum
-redis==3.5.3              # via -r requirements/base.txt, rq
-regex==2020.11.13         # via -r requirements/base.txt, awesome-slugify
-requests-mock==1.8.0      # via -r requirements/tests.in
-requests==2.25.1          # via requests-mock
-retrying==1.3.3           # via -r requirements/base.txt, plotly
-rq==1.7.0                 # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, behave, flake8-tuple, parse-type, pip-tools, plotly, python-dateutil, python-rex, requests-mock, retrying
-sortedcontainers==2.3.0   # via -r requirements/base.txt
-toml==0.10.2              # via pytest
-unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
-urllib3==1.26.3           # via -r requirements/base.txt, requests
-wcwidth==0.2.5            # via prompt-toolkit
+appdirs==1.4.4
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+    #   virtualenv
+attrs==20.3.0
+    # via
+    #   -r requirements/dev.txt
+    #   hypothesis
+    #   pytest
+awesome-slugify==1.6.5
+    # via -r requirements/dev.txt
+base58==2.1.0
+    # via -r requirements/dev.txt
+bcrypt==3.2.0
+    # via
+    #   -r requirements/dev.txt
+    #   paramiko
+behave==1.2.6
+    # via -r requirements/tests.in
+cached-property==1.5.2
+    # via -r requirements/dev.txt
+certifi==2020.12.5
+    # via requests
+cffi==1.14.4
+    # via
+    #   -r requirements/dev.txt
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+cfgv==3.2.0
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+chardet==4.0.0
+    # via requests
+click-default-group==1.2.2
+    # via -r requirements/dev.txt
+click==7.1.2
+    # via
+    #   -r requirements/dev.txt
+    #   click-default-group
+    #   pip-tools
+    #   rq
+colorlog==4.7.2
+    # via -r requirements/dev.txt
+coverage==5.3
+    # via -r requirements/tests.in
+cryptography==3.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   paramiko
+deepdiff==5.0.2
+    # via -r requirements/tests.in
+distlib==0.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   virtualenv
+entrypoints==0.3
+    # via flake8
+fabric3==1.14.post1
+    # via -r requirements/dev.txt
+filelock==3.0.12
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+    #   virtualenv
+flake8-tuple==0.4.1
+    # via -r requirements/tests.in
+flake8==3.7.9
+    # via
+    #   -r requirements/tests.in
+    #   flake8-tuple
+hypothesis==4.38.0
+    # via -r requirements/tests.in
+identify==1.5.10
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+idna==2.10
+    # via requests
+iniconfig==1.1.1
+    # via pytest
+isort==5.6.4
+    # via -r requirements/tests.in
+jedi==0.17.2
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+mccabe==0.6.1
+    # via flake8
+nodeenv==1.5.0
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+numpy==1.19.4
+    # via -r requirements/dev.txt
+ordered-set==4.0.2
+    # via deepdiff
+packaging==20.7
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+parameterized==0.7.4
+    # via -r requirements/tests.in
+paramiko==2.7.2
+    # via
+    #   -r requirements/dev.txt
+    #   fabric3
+parse-type==0.5.2
+    # via behave
+parse==1.18.0
+    # via
+    #   behave
+    #   parse-type
+parso==0.7.1
+    # via
+    #   -r requirements/dev.txt
+    #   jedi
+pendulum==2.1.2
+    # via -r requirements/dev.txt
+pip-tools==5.4.0
+    # via -r requirements/dev.txt
+plotly==4.14.1
+    # via -r requirements/dev.txt
+pluggy==0.13.1
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+pre-commit==2.9.3
+    # via -r requirements/dev.txt
+prompt-toolkit==3.0.8
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+psutil==5.7.3
+    # via -r requirements/dev.txt
+ptpython==3.0.7
+    # via -r requirements/dev.txt
+py==1.9.0
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+pycodestyle==2.5.0
+    # via flake8
+pycparser==2.20
+    # via
+    #   -r requirements/dev.txt
+    #   cffi
+pyflakes==2.1.1
+    # via flake8
+pygments==2.8.1
+    # via
+    #   -r requirements/dev.txt
+    #   ptpython
+pynacl==1.4.0
+    # via
+    #   -r requirements/dev.txt
+    #   paramiko
+pyparsing==2.4.7
+    # via
+    #   -r requirements/dev.txt
+    #   packaging
+pytest==6.1.2
+    # via -r requirements/tests.in
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/dev.txt
+    #   pendulum
+python-rex==0.4
+    # via -r requirements/dev.txt
+pytz==2020.5
+    # via -r requirements/dev.txt
+pytzdata==2020.1
+    # via
+    #   -r requirements/dev.txt
+    #   pendulum
+pyyaml==5.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+redis==3.5.3
+    # via
+    #   -r requirements/dev.txt
+    #   rq
+regex==2020.11.13
+    # via
+    #   -r requirements/dev.txt
+    #   awesome-slugify
+requests-mock==1.8.0
+    # via -r requirements/tests.in
+requests==2.25.1
+    # via requests-mock
+retrying==1.3.3
+    # via
+    #   -r requirements/dev.txt
+    #   plotly
+rq==1.7.0
+    # via -r requirements/dev.txt
+six==1.15.0
+    # via
+    #   -r requirements/dev.txt
+    #   bcrypt
+    #   behave
+    #   cryptography
+    #   fabric3
+    #   flake8-tuple
+    #   parse-type
+    #   pip-tools
+    #   plotly
+    #   pynacl
+    #   python-dateutil
+    #   python-rex
+    #   requests-mock
+    #   retrying
+    #   tox
+    #   virtualenv
+sortedcontainers==2.3.0
+    # via -r requirements/dev.txt
+toml==0.10.2
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+    #   pytest
+    #   tox
+tox==3.20.1
+    # via -r requirements/dev.txt
+unidecode==0.4.21
+    # via
+    #   -r requirements/dev.txt
+    #   awesome-slugify
+urllib3==1.26.3
+    # via
+    #   -r requirements/dev.txt
+    #   requests
+virtualenv==20.2.2
+    # via
+    #   -r requirements/dev.txt
+    #   pre-commit
+    #   tox
+wcwidth==0.2.5
+    # via
+    #   -r requirements/dev.txt
+    #   prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
 	pip-tools
 	coverage
 commands =
-	pip-sync requirements/base.txt requirements/tests.txt
+	pip-sync requirements/tests.txt
 	pip install -e .
 	coverage run -m py.test {posargs:tests}
 
@@ -59,7 +59,7 @@ deps =
 	pip-tools
 	coverage
 commands =
-    pip-sync requirements/base.txt requirements/tests.txt
+    pip-sync requirements/tests.txt
     pip install -e .
     coverage run -m py.test {posargs:tests}
     coverage combine
@@ -73,7 +73,7 @@ deps =
 	coverage
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/base.txt requirements/tests.txt requirements/pandapower.txt
+    pip-sync requirements/tests.txt requirements/pandapower.txt
     pip install -e .
     flake8
     coverage run -m py.test {posargs:tests}


### PR DESCRIPTION
Some environments were relying on reciprocally incompatible dependencies.

For example, `ptpython` was definied in both `tests.in` and `dev.in`. In order to keep it internally compatible with the other packages of each environment, `pip-tool` will install a different version of its sub-dependency `pygments` in the two environments.
`fab sync` therefore tried to sync all the requirement files (`base.txt`, `dev.txt` and `tests.txt`) and failed.

In order to fix this problem (and a similar problem with `pandapower.txt`) we refactor the inheritance between requirements files. We make both `tests.in` and `pandapower.in` depend on `dev.txt`.