### PR TITLE
D3ASIM-2540: Set global market maker rate in instantiation of Infinit…

### DIFF
--- a/src/d3a/models/strategy/infinite_bus.py
+++ b/src/d3a/models/strategy/infinite_bus.py
@@ -38,10 +38,6 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
         self.buying_rate_profile = buying_rate_profile
         self.energy_rate = energy_sell_rate
         self.energy_rate_profile = energy_rate_profile
-        # This is done to support the UI which handles the Infinite Bus only as a Market Maker.
-        # If one plans to allow multiple Infinite Bus devices in the grid, this should be
-        # amended.
-        GlobalConfig.market_maker_rate = self.energy_rate
 
     def event_activate(self, **kwargs):
         if self.energy_rate_profile is not None:
@@ -59,6 +55,10 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
             self.energy_buy_rate = self.area.config.market_maker_rate \
                 if self.energy_buy_rate is None \
                 else read_arbitrary_profile(InputProfileTypes.IDENTITY, self.energy_buy_rate)
+        # This is done to support the UI which handles the Infinite Bus only as a Market Maker.
+        # If one plans to allow multiple Infinite Bus devices in the grid, this should be
+        # amended.
+        GlobalConfig.market_maker_rate = self.energy_rate
 
     def buy_energy(self, market):
         for offer in market.sorted_offers:

--- a/src/d3a/models/strategy/infinite_bus.py
+++ b/src/d3a/models/strategy/infinite_bus.py
@@ -39,6 +39,25 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
         self.energy_rate = energy_sell_rate
         self.energy_rate_profile = energy_rate_profile
 
+        # This is done to support the UI which handles the Infinite Bus only as a Market Maker.
+        # If one plans to allow multiple Infinite Bus devices in the grid, this should be
+        # amended.
+        self._set_market_maker_rate()
+
+    def _set_market_maker_rate(self):
+        if self.energy_rate_profile is not None:
+            GlobalConfig.market_maker_rate = \
+                read_and_convert_identity_profile_to_float(self.energy_rate_profile)
+            del self.energy_rate_profile
+        elif isinstance(self.energy_rate, int):
+            GlobalConfig.market_maker_rate = self.energy_rate
+        elif isinstance(self.energy_rate, str):
+            GlobalConfig.market_maker_rate = \
+                read_arbitrary_profile(InputProfileTypes.IDENTITY, self.energy_rate)
+        else:
+            GlobalConfig.market_maker_rate = \
+                ConstSettings.GeneralSettings.DEFAULT_MARKET_MAKER_RATE
+
     def event_activate(self, **kwargs):
         if self.energy_rate_profile is not None:
             self.energy_rate = read_and_convert_identity_profile_to_float(self.energy_rate_profile)
@@ -55,10 +74,6 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
             self.energy_buy_rate = self.area.config.market_maker_rate \
                 if self.energy_buy_rate is None \
                 else read_arbitrary_profile(InputProfileTypes.IDENTITY, self.energy_buy_rate)
-        # This is done to support the UI which handles the Infinite Bus only as a Market Maker.
-        # If one plans to allow multiple Infinite Bus devices in the grid, this should be
-        # amended.
-        GlobalConfig.market_maker_rate = self.energy_rate
 
     def buy_energy(self, market):
         for offer in market.sorted_offers:

--- a/src/d3a/models/strategy/infinite_bus.py
+++ b/src/d3a/models/strategy/infinite_bus.py
@@ -38,7 +38,6 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
         self.buying_rate_profile = buying_rate_profile
         self.energy_rate = energy_sell_rate
         self.energy_rate_profile = energy_rate_profile
-
         # This is done to support the UI which handles the Infinite Bus only as a Market Maker.
         # If one plans to allow multiple Infinite Bus devices in the grid, this should be
         # amended.
@@ -48,7 +47,6 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
         if self.energy_rate_profile is not None:
             GlobalConfig.market_maker_rate = \
                 read_and_convert_identity_profile_to_float(self.energy_rate_profile)
-            del self.energy_rate_profile
         elif isinstance(self.energy_rate, int):
             GlobalConfig.market_maker_rate = self.energy_rate
         elif isinstance(self.energy_rate, str):

--- a/src/d3a/models/strategy/infinite_bus.py
+++ b/src/d3a/models/strategy/infinite_bus.py
@@ -49,7 +49,7 @@ class InfiniteBusStrategy(CommercialStrategy, BidEnabledStrategy):
                 read_and_convert_identity_profile_to_float(self.energy_rate_profile)
         elif isinstance(self.energy_rate, int):
             GlobalConfig.market_maker_rate = self.energy_rate
-        elif isinstance(self.energy_rate, str):
+        elif isinstance(self.energy_rate, str) or isinstance(self.energy_rate, dict):
             GlobalConfig.market_maker_rate = \
                 read_arbitrary_profile(InputProfileTypes.IDENTITY, self.energy_rate)
         else:

--- a/tests/test_strategy_infinite_bus.py
+++ b/tests/test_strategy_infinite_bus.py
@@ -24,8 +24,9 @@ from d3a.models.market.market_structures import Offer, Trade, BalancingOffer, Bi
 from d3a.models.strategy.infinite_bus import InfiniteBusStrategy
 from d3a.models.area import DEFAULT_CONFIG
 from d3a.d3a_core.device_registry import DeviceRegistry
-from d3a_interface.constants_limits import ConstSettings
+from d3a_interface.constants_limits import ConstSettings, GlobalConfig
 from d3a.constants import TIME_ZONE
+from d3a_interface.utils import find_object_of_same_weekday_and_time
 
 TIME = pendulum.today(tz=TIME_ZONE).at(hour=10, minute=45, second=0)
 
@@ -126,6 +127,15 @@ def bus_test1(area_test1):
     c.area = area_test1
     c.owner = area_test1
     return c
+
+
+def test_global_market_maker_rate_set_at_instantiation(area_test1):
+    strategy = InfiniteBusStrategy(energy_sell_rate=35)
+    assert strategy.energy_rate == GlobalConfig.market_maker_rate
+    strategy = InfiniteBusStrategy(energy_rate_profile={"01:15": 40})
+    timestamp_key = pendulum.today("utc").set(hour=1, minute=15)
+    rate = find_object_of_same_weekday_and_time(GlobalConfig.market_maker_rate, timestamp_key)
+    assert rate == 40
 
 
 def testing_offer_is_created_at_first_market_not_on_activate(bus_test1, area_test1):


### PR DESCRIPTION
The bug was because the `src/d3a/models/strategy/load_hours.py:232` 
```python
    def event_activate_price(self):
        # If use_market_maker_rate is true, overwrite final_buying_rate to market maker rate
        if self.use_market_maker_rate:
            self._area_reconfigure_prices(
                final_buying_rate=get_market_maker_rate_from_config(
                    self.area.next_market, 0) + self.owner.get_path_to_root_fees(), validate=False) #here
```
The get_market_maker_rate_from_config is accessing the `GlobalConfig.market_maker_rate` which is a str path atm
loading it in the instantiation phase solves it 