### PR TITLE
D3ASIM-3480: Also update the total_demanded_energy for the LoadForeca…

### DIFF
--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -445,9 +445,7 @@ class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
         energy_forecast_Wh = self.energy_forecast_buffer_Wh
         slot_time = self.area.next_market.time_slot
         self.state.set_desired_energy(energy_forecast_Wh, slot_time, overwrite=True)
-        # TODO: Check self-sufficiency / self-consumption of LoadForecastExternalStrategy and
-        #  and consider re-adding:
-        # self.state.update_total_demanded_energy(slot_time)
+        self.state.update_total_demanded_energy(slot_time)
 
     def _update_energy_requirement_future_markets(self):
         """


### PR DESCRIPTION
…stExternalStrategy.

Before the fix for an example CN, the KPIs were:
```
{
  "data": {
    "simulationResults": {
      "kpi": "{"self_consumption": 100.0, 
      "self_sufficiency": 0.0, 
      "demanded_buffer_wh": 0, 
      "total_energy_demanded_wh": 97, 
      "total_energy_produced_wh": 0.9500000000000006, 
      "total_self_consumption_wh": 0.9500000000000006, 
      "self_consumption_buffer_wh": 0}"
    }
  }
}
```

After the fix:
```
{
  "data": {
    "simulationResults": {
      "kpi": "{"self_consumption": 100.0, 
      "self_sufficiency": 0.9793814432989698, 
      "demanded_buffer_wh": 0, 
      "total_energy_demanded_wh": 97, 
      "total_energy_produced_wh": 0.9500000000000006, 
      "total_self_consumption_wh": 0.9500000000000006, 
      "self_consumption_buffer_wh": 0}"
    }
  }
}
```

Have a look at the `self_sufficiency` member.
We new before that this might be an issue (see the deleted TODO comment). Unfortunately, this will not fix the existing CNs on production. 
