### PR TITLE
Use the default % log formatting style

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -193,7 +193,7 @@ never-returning-functions=sys.exit
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=new
+logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.


### PR DESCRIPTION
Thanks to pylint warnings, I found out that the logging library is optimized to use the `%` formatting style. The `%` syntax allows to lazily evaluate strings only when they're needed, without interpolating them before they're sent to the logger.

This would be an example of a good format message:
```python
import logging
logger = logging.getLogger()
logger.error("Hello %s", "world")  # This is not an interpolated string! They are two separate parameters
```

Note the difference between these:
```python
# Lazily evaluated by the logger (good)
logger.error("Hello %s", "world")

# Interpolated before being sent to the logger (not good)
logger.error("Hello %s" % "world")
logger.error("Hello {}".format("world"))
foo = "world"
logger.error(f"Hello {foo}"))
```

This is important not just because of optimization. Suppose we try to log something that will raise an exception (for example using `%d` with `None`):
```python
logger.error("Hello %d", None)  # Good: it will crash and log the error
logger.error("Hello %d" % None)  # Bad: it will crash without logging anything
```

So it looks like the best thing would be to use `%` in logger strings and the additional parameters to populate them.

## Info

- [Using particular formatting styles throughout your application](https://docs.python.org/3.8/howto/logging-cookbook.html#formatting-styles)
- [Lazy evaluation of strings in python logging: comparing `%` with `.format`](https://stackoverflow.com/questions/52012564/lazy-evaluation-of-strings-in-python-logging-comparing-with-format/52012660)

There's the possibility to change this and use `str.format()` style, but this would need to be changed at the formatter level (see [`logging.Formatter`](https://docs.python.org/3.8/library/logging.html#logging.Formatter)).