### PR TITLE
Fix case when offer is None in Home Meter tick event

### DIFF
--- a/src/d3a/models/strategy/home_meter.py
+++ b/src/d3a/models/strategy/home_meter.py
@@ -534,7 +534,7 @@ class HomeMeterStrategy(BidEnabledStrategy):
             return
         if not offer and not market.offers:
             return
-        if offer.id not in market.offers:
+        if offer and offer.id not in market.offers:
             return
 
         try:


### PR DESCRIPTION
This PR corrects some `if` statements that were causing exceptions when no offers were present.