### PR TITLE
 Revert d3a-interface installation in setup.py

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,9 @@ coverage:
         target: auto  # Compare coverage to the previous base commit (PR base or parent commit)
         informational: false  # If true, status will always pass
 
+ignore:
+  - "setup.py"
+
 comment:
   layout: "diff"
   behavior: default

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
+import os
 from setuptools import find_packages, setup
 
+d3a_interface_branch = os.environ.get("BRANCH", "master")
 
 try:
     with open("requirements/dev.txt") as req:
         REQUIREMENTS = [r.partition("#")[0] for r in req if not r.startswith("-e")]
+        REQUIREMENTS.extend(
+            [f"d3a-interface @ "
+             f"git+https://github.com/gridsingularity/d3a-interface.git@{d3a_interface_branch}"
+             ])
 except OSError:
     # Shouldn't happen
     REQUIREMENTS = []


### PR DESCRIPTION
I have recently adapted to a suggestion to remove the d3a-interface installation from setup.py as it is already covered in the requirements
However, there is a check here that skips the requirements starting with -e prefix, so the d3a-interface was being skipped and the deploys were failing
I have reverted the original setup in this PR