### PR TITLE
D3ASIM-3598: fix issues with timeslot parameter

### DIFF
--- a/src/d3a/models/strategy/external_strategies/__init__.py
+++ b/src/d3a/models/strategy/external_strategies/__init__.py
@@ -216,7 +216,7 @@ class ExternalMixin:
         return self.market_area.next_market
 
     def _get_market_from_command_argument(self, arguments: Dict):
-        if "timeslot" not in arguments:
+        if arguments.get("timeslot") is None:
             return self.next_market
         timeslot = str_to_pendulum_datetime(arguments["timeslot"])
         return self._get_market_from_timeslot(timeslot)

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -166,7 +166,8 @@ class PVExternalMixin(ExternalMixin):
                 market,
                 replace_existing=replace_existing)
 
-            offer_arguments = {k: v for k, v in arguments.items() if not k == "transaction_id"}
+            offer_arguments = {
+                k: v for k, v in arguments.items() if k not in ["transaction_id", "timeslot"]}
             offer = self.post_offer(
                 market, replace_existing=replace_existing, **offer_arguments)
 
@@ -319,7 +320,7 @@ class PVExternalMixin(ExternalMixin):
 
             offer_arguments = {k: v
                                for k, v in arguments.items()
-                               if k not in ["transaction_id", "type"]}
+                               if k not in ["transaction_id", "type", "timeslot"]}
 
             offer = self.post_offer(
                 market, replace_existing=replace_existing, **offer_arguments)

--- a/src/d3a/models/strategy/external_strategies/storage.py
+++ b/src/d3a/models/strategy/external_strategies/storage.py
@@ -186,7 +186,8 @@ class StorageExternalMixin(ExternalMixin):
 
     def _offer_impl(self, arguments, response_channel):
         try:
-            offer_arguments = {k: v for k, v in arguments.items() if not k == "transaction_id"}
+            offer_arguments = {
+                k: v for k, v in arguments.items() if k not in ["transaction_id", "timeslot"]}
 
             replace_existing = offer_arguments.pop("replace_existing", True)
             market = self._get_market_from_command_argument(arguments)
@@ -502,7 +503,9 @@ class StorageExternalMixin(ExternalMixin):
         with self.lock:
             try:
                 offer_arguments = {
-                    k: v for k, v in arguments.items() if k not in ["transaction_id", "type"]}
+                    k: v for k, v in arguments.items()
+                    if k not in ["transaction_id", "type", "timeslot"]}
+
                 assert self.can_offer_be_posted(market.time_slot, **offer_arguments)
 
                 replace_existing = offer_arguments.pop("replace_existing", True)


### PR DESCRIPTION
The `timeslot` parameter is breaking the current implementation for bids and offers:
- when the bid/offer arguments contains `{"timeslot": None}`
- when the `timeslot` parameter is passed to the `Offer` as an init parameter

This PR fixes these issues restoring the correct functionality of our integration tests (on the d3a-api-client side).