### PR TITLE
D3ASIM-3421: Conditionally select the appropriate psycopg2 package ac…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import platform
+
 from setuptools import find_packages, setup
 
 d3a_interface_branch = "master"
@@ -15,6 +17,11 @@ except OSError:
 
 with open("README.rst", "r") as readme:
     README = readme.read()
+
+if platform.python_implementation() == "PyPy":
+    REQUIREMENTS.append("psycopg2cffi==2.9.0")
+else:
+    REQUIREMENTS.append("psycopg2==2.9.1")
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
 VERSION = "1.1.0"


### PR DESCRIPTION
…cording to whether Pypy or cPython is the current interpreter.

Default Postgres driver implementation in Python (psycopg2) cannot be installed via pip on cPython (to be more precise, cannot be compiled, since it is a C library with Python wrappers). In order for the Postgres driver to be installed in Pypy, psycopg2cffi package needs to be installed (which is the same C driver using cffi bindings). 

The separation on the installation path needs to be done in setup.py in order to cover all cases (docker version is using Pypy, locally cPython is used but for debugging purposes Pypy should also be supported)