### PR TITLE
Stripped out timezone information from the datapoints read from the D…

### DIFF
--- a/src/d3a/constants.py
+++ b/src/d3a/constants.py
@@ -57,7 +57,7 @@ CN_PROFILE_EXPANSION_DAYS = 7
 
 RUN_IN_REALTIME = False
 
-CONNECT_TO_PROFILES_DB = False
+CONNECT_TO_PROFILES_DB = True
 
 
 class SettlementTemplateStrategiesConstants:

--- a/src/d3a/constants.py
+++ b/src/d3a/constants.py
@@ -57,7 +57,7 @@ CN_PROFILE_EXPANSION_DAYS = 7
 
 RUN_IN_REALTIME = False
 
-CONNECT_TO_PROFILES_DB = True
+CONNECT_TO_PROFILES_DB = False
 
 
 class SettlementTemplateStrategiesConstants:

--- a/src/d3a/d3a_core/user_profile_handler.py
+++ b/src/d3a/d3a_core/user_profile_handler.py
@@ -20,13 +20,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import Dict
 
-import pendulum
 import pytz
 from d3a_interface.constants_limits import GlobalConfig, TIME_ZONE
 from d3a_interface.read_user_profile import read_arbitrary_profile, InputProfileTypes
 from d3a_interface.utils import generate_market_slot_list
-from pendulum import DateTime
-from pendulum import instance
+from pendulum import DateTime, instance, duration
 from pony.orm import Database, Required, db_session, select
 from pony.orm.core import Query
 
@@ -62,7 +60,7 @@ class ProfileDBConnectionHandler:
 
     @staticmethod
     def strip_timezone_and_create_pendulum_instance_from_datetime(
-            time_stamp: datetime) -> pendulum.DateTime:
+            time_stamp: datetime) -> DateTime:
         return instance(time_stamp.astimezone(timezone.utc), pytz.UTC)
 
     def connect(self):
@@ -105,7 +103,7 @@ class ProfileDBConnectionHandler:
             datapoint for datapoint in self.Profile_Database_ProfileTimeSeries
             if datapoint.profile_uuid == profile_uuid
             and datapoint.time >= first_datapoint_time
-            and datapoint.time <= first_datapoint_time + pendulum.duration(days=7)
+            and datapoint.time <= first_datapoint_time + duration(days=7)
         )
 
         datapoint_dict = {

--- a/src/d3a/models/strategy/predefined_load.py
+++ b/src/d3a/models/strategy/predefined_load.py
@@ -104,6 +104,10 @@ class DefinedLoadStrategy(LoadHoursStrategy):
         self._read_or_rotate_profiles()
         super().event_activate_energy()
 
+    def event_market_cycle(self):
+        self._read_or_rotate_profiles()
+        super().event_market_cycle()
+
     def _update_energy_requirement_future_markets(self):
         """
         Update required energy values for each market slot.


### PR DESCRIPTION
…B, in order to sync with the naive timezones in d3a. Enabled constant to read the profiles from the database. Added check for whether the profiles need to be read or rotated for the predefined load strategy.