### PR TITLE
External strategy abc

### DIFF
--- a/src/d3a/models/strategy/external_strategies/__init__.py
+++ b/src/d3a/models/strategy/external_strategies/__init__.py
@@ -19,7 +19,7 @@ import json
 import logging
 from collections import deque, namedtuple
 from threading import Lock
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, Callable
 
 from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.data_classes import Trade
@@ -123,6 +123,18 @@ class ExternalMixin:
     Although that the direct device connection is disabled (only aggregators can connect),
     we still have the remnants functionality of when we used to have this feature.
     """
+
+    # Due to the dependencies of these mixins (they need to have more precedence in the MRO than
+    # the strategy class methods in order to override them) this class cannot be abstract, because
+    # it would expose unimplemented abstract methods to the concrete class. Therefore the best
+    # alternative is to include here the mixed-in class dependencies as type annotations
+    area: "Area"
+    owner: "Area"
+    deactivate: Callable
+    get_state: Callable
+    restore_state: Callable
+    energy_traded: Callable
+    energy_traded_costs: Callable
 
     def __init__(self, *args, **kwargs):
         self._is_registered: bool = False  # The client asked to get connected

--- a/src/d3a/models/strategy/external_strategies/__init__.py
+++ b/src/d3a/models/strategy/external_strategies/__init__.py
@@ -475,8 +475,8 @@ class ExternalMixin:
             f"List offers command not supported on device {self.device.uuid}")
 
     @property
-    def _command_callback_mapping(self) -> Dict:
-        """Map the command types to their adjacent callbacks."""
+    def _aggregator_command_callback_mapping(self) -> Dict:
+        """Map the aggregator command types to their adjacent callbacks."""
         return {
             "bid": self._bid_aggregator,
             "delete_bid": self._delete_bid_aggregator,
@@ -503,7 +503,7 @@ class ExternalMixin:
                     "area_uuid": self.device.uuid,
                     "message": "Invalid command type"}
 
-            callback = self._command_callback_mapping.get(command["type"])
+            callback = self._aggregator_command_callback_mapping.get(command["type"])
             if callback is None:
                 return {
                     "command": command["type"], "status": "error",

--- a/src/d3a/models/strategy/external_strategies/forecast_mixin.py
+++ b/src/d3a/models/strategy/external_strategies/forecast_mixin.py
@@ -180,10 +180,5 @@ class ForecastExternalMixin(ExternalMixin):
             if energy < 0.0:
                 raise ValueError(f"Energy is not positive for time stamp {time_str}.")
 
-    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False) -> None:
-        """
-        Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
-        """
-
     def _read_or_rotate_profiles(self, reconfigure=False) -> None:
         """Overridden with empty implementation to disable reading profile from DB."""

--- a/src/d3a/models/strategy/external_strategies/forecast_mixin.py
+++ b/src/d3a/models/strategy/external_strategies/forecast_mixin.py
@@ -1,0 +1,189 @@
+import json
+import logging
+from collections import deque
+from typing import Dict
+
+from d3a_interface.utils import convert_str_to_pendulum_in_dict
+from pendulum import DateTime
+
+from d3a.models.strategy.external_strategies import IncomingRequest, ExternalMixin
+
+
+class ForecastExternalMixin(ExternalMixin):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Buffers for energy forecast and measurement values,
+        # that have been sent by the d3a-api-client in the duration of one market slot
+        self.energy_forecast_buffer: Dict[DateTime, float] = {}
+        self.energy_measurement_buffer: Dict[DateTime, float] = {}
+
+    def event_tick(self):
+        """Set the energy forecast using pending requests. Extends super implementation.
+
+        This method is triggered by the TICK event.
+        """
+        # Need to repeat he pending request parsing in order to handle power forecasts
+        # from the MQTT subscriber (non-connected admin)
+        for req in self.pending_requests:
+            if req.request_type == "set_energy_forecast":
+                self._set_energy_forecast_impl(req.arguments, req.response_channel)
+            elif req.request_type == "set_energy_measurement":
+                self._set_energy_measurement_impl(req.arguments, req.response_channel)
+
+        self.pending_requests = deque(
+            req for req in self.pending_requests
+            if req.request_type not in ["set_energy_forecast", "set_energy_measurement"])
+
+        super().event_tick()
+
+    def _incoming_commands_callback_selection(self, req: IncomingRequest) -> None:
+        """Map commands to callbacks for forecast and measurement reading."""
+        if req.request_type == "set_energy_forecast":
+            self._set_energy_forecast_impl(req.arguments, req.response_channel)
+        elif req.request_type == "set_energy_measurement":
+            self._set_energy_measurement_impl(req.arguments, req.response_channel)
+        else:
+            super()._incoming_commands_callback_selection(req)
+
+    @property
+    def channel_dict(self) -> Dict:
+        """Extend channel_dict property with forecast related channels."""
+        return {**super().channel_dict,
+                f"{self.channel_prefix}/set_energy_forecast": self._set_energy_forecast,
+                f"{self.channel_prefix}/set_energy_measurement": self._set_energy_measurement}
+
+    def event_market_cycle(self) -> None:
+        """Update forecast and measurement in state by reading from buffers."""
+        self.update_energy_forecast()
+        self.update_energy_measurement()
+        self._clear_energy_buffers()
+        super().event_market_cycle()
+
+    def _clear_energy_buffers(self) -> None:
+        """Clear forecast and measurement buffers."""
+        self.energy_forecast_buffer = {}
+        self.energy_measurement_buffer = {}
+
+    def event_activate_energy(self) -> None:
+        """This strategy does not need to initiate energy values as they are sent via the API."""
+        self._clear_energy_buffers()
+
+    @property
+    def _aggregator_command_callback_mapping(self) -> Dict:
+        """Add the forecast and measurement callbacks to the command mapping."""
+        return {
+            **super()._aggregator_command_callback_mapping,
+            "set_energy_forecast": self._set_energy_forecast_aggregator,
+            "set_energy_measurement": self._set_energy_measurement_aggregator
+        }
+
+    def _set_energy_forecast(self, payload: Dict) -> None:
+        """Callback for set_energy_forecast redis endpoint."""
+        self._set_device_energy_data(payload, "set_energy_forecast", "energy_forecast")
+
+    def _set_energy_measurement(self, payload: Dict) -> None:
+        """Callback for set_energy_measurement redis endpoint."""
+        self._set_device_energy_data(payload, "set_energy_measurement", "energy_measurement")
+
+    def _set_device_energy_data(self, payload: Dict, command_type: str,
+                                energy_data_arg_name: str) -> None:
+        transaction_id = self._get_transaction_id(payload)
+        energy_data_response_channel = f"{self.channel_prefix}/response/{command_type}"
+        arguments = json.loads(payload["data"])
+        if set(arguments.keys()) == {energy_data_arg_name, "transaction_id"}:
+            self.pending_requests.append(
+                IncomingRequest(command_type, arguments,
+                                energy_data_response_channel))
+        else:
+            logging.exception("Incorrect %s request: Payload %s", command_type, payload)
+            self.redis.publish_json(
+                energy_data_response_channel,
+                {"command": command_type,
+                 "error": f"Incorrect {command_type} request. "
+                          f"Available parameters: ({energy_data_arg_name}).",
+                 "transaction_id": transaction_id})
+
+    def _set_energy_forecast_impl(self, arguments: Dict, response_channel: str) -> None:
+        self._set_device_energy_data_impl(arguments, response_channel, "set_energy_forecast")
+
+    def _set_energy_measurement_impl(self, arguments: Dict, response_channel: str) -> None:
+        self._set_device_energy_data_impl(arguments, response_channel, "set_energy_measurement")
+
+    def _set_device_energy_data_impl(self, arguments: Dict, response_channel: str,
+                                     command_type: str) -> None:
+        """
+        Digest command from buffer and perform set_energy_forecast or set_energy_measurement.
+        Args:
+            arguments: Dictionary containing "energy_forecast/energy_measurement" that is a dict
+                containing a profile
+                key: time string, value: energy in kWh
+            response_channel: redis channel string where the response should be sent to
+        """
+        try:
+            self._set_device_energy_data_state(command_type, arguments)
+            response = {"command": command_type, "status": "ready",
+                        "transaction_id": arguments.get("transaction_id")}
+        except (Exception, ):
+            error_message = (f"Error when handling _{command_type}_impl "
+                             f"on area {self.device.name}. Arguments: {arguments}")
+            logging.exception(error_message)
+            response = {"command": command_type, "status": "error",
+                        "error_message": error_message,
+                        "transaction_id": arguments.get("transaction_id")}
+        self.redis.publish_json(response_channel, response)
+
+    def _set_energy_forecast_aggregator(self, arguments: Dict) -> Dict:
+        """Callback for the set_energy_forecast endpoint when sent by aggregator."""
+        return self._set_device_energy_data_aggregator(arguments, "set_energy_forecast")
+
+    def _set_energy_measurement_aggregator(self, arguments: Dict) -> Dict:
+        """Callback for the set_energy_measurement endpoint when sent by aggregator."""
+        return self._set_device_energy_data_aggregator(arguments, "set_energy_measurement")
+
+    def _set_device_energy_data_aggregator(self, arguments: Dict, command_name: str) -> Dict:
+        try:
+            self._set_device_energy_data_state(command_name, arguments)
+            response = {
+                "command": command_name, "status": "ready",
+                command_name: arguments,
+                "area_uuid": self.device.uuid,
+                "transaction_id": arguments.get("transaction_id")}
+        except (Exception, ):
+            logging.exception("Error when handling bid on area %s", self.device.name)
+            response = {
+                "command": command_name, "status": "error",
+                "area_uuid": self.device.uuid,
+                "error_message": f"Error when handling {command_name} "
+                                 f"on area {self.device.name} with arguments {arguments}.",
+                "transaction_id": arguments.get("transaction_id")}
+        return response
+
+    def _set_device_energy_data_state(self, command_type: str, arguments: Dict) -> None:
+        """Update the state of the device with forecast and measurement data."""
+        if command_type == "set_energy_forecast":
+            self._validate_values_positive_in_profile(arguments["energy_forecast"])
+            self.energy_forecast_buffer.update(
+                convert_str_to_pendulum_in_dict(arguments["energy_forecast"]))
+        elif command_type == "set_energy_measurement":
+            self._validate_values_positive_in_profile(arguments["energy_measurement"])
+            self.energy_measurement_buffer.update(
+                convert_str_to_pendulum_in_dict(arguments["energy_measurement"]))
+        else:
+            assert False, f"Unsupported command {command_type}, available commands: " \
+                          "set_energy_forecast, set_energy_measurement"
+
+    @staticmethod
+    def _validate_values_positive_in_profile(profile: Dict) -> None:
+        """Validate whether all values are positive in a profile."""
+        for time_str, energy in profile.items():
+            if energy < 0.0:
+                raise ValueError(f"Energy is not positive for time stamp {time_str}.")
+
+    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False) -> None:
+        """
+        Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
+        """
+
+    def _read_or_rotate_profiles(self, reconfigure=False) -> None:
+        """Overridden with empty implementation to disable reading profile from DB."""

--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -17,7 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import json
 import logging
-from collections import deque
 from typing import Dict, List, Union
 
 from d3a_interface.constants_limits import ConstSettings
@@ -27,6 +26,7 @@ from d3a.d3a_core.util import get_market_maker_rate_from_config
 from d3a.models.market import Market
 from d3a.models.strategy.external_strategies import (
     ExternalMixin, IncomingRequest, default_market_info, ExternalStrategyConnectionManager)
+from d3a.models.strategy.external_strategies.forecast_mixin import ForecastExternalMixin
 from d3a.models.strategy.load_hours import LoadHoursStrategy
 from d3a.models.strategy.predefined_load import DefinedLoadStrategy
 
@@ -362,7 +362,7 @@ class LoadProfileExternalStrategy(LoadExternalMixin, DefinedLoadStrategy):
     pass
 
 
-class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
+class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStrategy):
     """
         Strategy responsible for reading forecast and measurement consumption data via hardware API
     """
@@ -396,62 +396,6 @@ class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
                          balancing_energy_ratio=balancing_energy_ratio,
                          use_market_maker_rate=use_market_maker_rate)
 
-        # Buffers for energy forecast and measurement values,
-        # that have been sent by the d3a-api-client in the duration of one market slot
-        self.energy_forecast_buffer = {}  # Dict[DateTime, float]
-        self.energy_measurement_buffer = {}  # Dict[DateTime, float]
-
-    @property
-    def channel_dict(self):
-        """Extend channel_dict property with forecast related channels."""
-        return {**super().channel_dict,
-                f"{self.channel_prefix}/set_energy_forecast": self._set_energy_forecast,
-                f"{self.channel_prefix}/set_energy_measurement": self._set_energy_measurement}
-
-    def event_tick(self):
-        """Set the energy forecast using pending requests. Extends super implementation.
-
-        This method is triggered by the TICK event.
-        """
-        # Need to repeat he pending request parsing in order to handle power forecasts
-        # from the MQTT subscriber (non-connected admin)
-        for req in self.pending_requests:
-            if req.request_type == "set_energy_forecast":
-                self._set_energy_forecast_impl(req.arguments, req.response_channel)
-            elif req.request_type == "set_energy_measurement":
-                self._set_energy_measurement_impl(req.arguments, req.response_channel)
-
-        self.pending_requests = deque(
-            req for req in self.pending_requests
-            if req.request_type not in ["set_energy_forecast", "set_energy_measurement"])
-
-        super().event_tick()
-
-    def _incoming_commands_callback_selection(self, req):
-        """Map commands to callbacks for forecast and measurement reading."""
-        if req.request_type == "set_energy_forecast":
-            self._set_energy_forecast_impl(req.arguments, req.response_channel)
-        elif req.request_type == "set_energy_measurement":
-            self._set_energy_measurement_impl(req.arguments, req.response_channel)
-        else:
-            super()._incoming_commands_callback_selection(req)
-
-    def event_market_cycle(self):
-        """Update forecast and measurement in state by reading from buffers."""
-        self.update_energy_forecast()
-        self.update_energy_measurement()
-        self._clear_energy_buffers()
-        super().event_market_cycle()
-
-    def event_activate_energy(self):
-        """This strategy does not need to initiate energy values as they are sent via the API."""
-        self._clear_energy_buffers()
-
-    def _clear_energy_buffers(self):
-        """Clear forecast and measurement buffers."""
-        self.energy_forecast_buffer = {}
-        self.energy_measurement_buffer = {}
-
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""
         for slot_time, energy_kWh in self.energy_forecast_buffer.items():
@@ -464,11 +408,3 @@ class LoadForecastExternalStrategy(LoadProfileExternalStrategy):
         for slot_time, energy_kWh in self.energy_measurement_buffer.items():
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
-
-    def _update_energy_requirement_future_markets(self):
-        """
-        Setting demanded energy for the next slot is already done by update_energy_forecast
-        """
-
-    def _read_or_rotate_profiles(self, reconfigure=False):
-        """Overridden with empty implementation to disable reading profile from DB."""

--- a/src/d3a/models/strategy/external_strategies/load.py
+++ b/src/d3a/models/strategy/external_strategies/load.py
@@ -422,3 +422,8 @@ class LoadForecastExternalStrategy(ForecastExternalMixin, LoadProfileExternalStr
         for slot_time, energy_kWh in self.energy_measurement_buffer.items():
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
+
+    def _update_energy_requirement_future_markets(self):
+        """
+        Setting demanded energy for the next slot is already done by update_energy_forecast
+        """

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 class PVExternalMixin(ExternalMixin):
 
     state: "PVState"
-    offers: Offers
+    offers: "Offers"
     can_offer_be_posted: Callable
     post_offer: Callable
     set_produced_energy_forecast_kWh_future_markets: Callable
@@ -410,3 +410,8 @@ class PVForecastExternalStrategy(ForecastExternalMixin, PVPredefinedExternalStra
         for slot_time, energy_kWh in self.energy_measurement_buffer.items():
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
+
+    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False) -> None:
+        """
+        Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
+        """

--- a/src/d3a/models/strategy/external_strategies/pv.py
+++ b/src/d3a/models/strategy/external_strategies/pv.py
@@ -17,16 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import json
 import logging
-from collections import deque
 from typing import Dict
 
 from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.data_classes import Offer
-from pendulum import duration, DateTime
+from pendulum import duration
 
 from d3a.d3a_core.util import get_market_maker_rate_from_config
 from d3a.models.strategy.external_strategies import (
     ExternalMixin, IncomingRequest, ExternalStrategyConnectionManager, default_market_info)
+from d3a.models.strategy.external_strategies.forecast_mixin import ForecastExternalMixin
 from d3a.models.strategy.predefined_pv import PVPredefinedStrategy, PVUserProfileStrategy
 from d3a.models.strategy.pv import PVStrategy
 
@@ -359,7 +359,7 @@ class PVPredefinedExternalStrategy(PVExternalMixin, PVPredefinedStrategy):
     """Strategy class for external PV devices with predefined profile."""
 
 
-class PVForecastExternalStrategy(PVPredefinedExternalStrategy):
+class PVForecastExternalStrategy(ForecastExternalMixin, PVPredefinedExternalStrategy):
     """
         Strategy responsible for reading forecast and measurement production data via hardware API
     """
@@ -387,62 +387,6 @@ class PVForecastExternalStrategy(PVPredefinedExternalStrategy):
                          energy_rate_decrease_per_update=energy_rate_decrease_per_update,
                          use_market_maker_rate=use_market_maker_rate)
 
-        # Buffers for energy forecast and measurement values,
-        # that have been sent by the d3a-api-client in the duration of one market slot
-        self.energy_forecast_buffer: Dict[DateTime, float] = {}
-        self.energy_measurement_buffer: Dict[DateTime, float] = {}
-
-    @property
-    def channel_dict(self) -> Dict:
-        """Extend channel_dict property with forecast related channels."""
-        return {**super().channel_dict,
-                f"{self.channel_prefix}/set_energy_forecast": self._set_energy_forecast,
-                f"{self.channel_prefix}/set_energy_measurement": self._set_energy_measurement}
-
-    def event_tick(self) -> None:
-        """Set the energy forecast using pending requests. Extends super implementation.
-
-        This method is triggered by the TICK event.
-        """
-        # Need to repeat the pending request parsing in order to handle energy forecasts
-        # from the MQTT subscriber (non-connected admin)
-        for req in self.pending_requests:
-            if req.request_type == "set_energy_forecast":
-                self._set_energy_forecast_impl(req.arguments, req.response_channel)
-            elif req.request_type == "set_energy_measurement":
-                self._set_energy_measurement_impl(req.arguments, req.response_channel)
-
-        self.pending_requests = deque(
-            req for req in self.pending_requests
-            if req.request_type not in ["set_energy_forecast", "set_energy_measurement"])
-
-        super().event_tick()
-
-    def _incoming_commands_callback_selection(self, req: IncomingRequest) -> None:
-        """Map commands to callbacks for forecast and measurement reading."""
-        if req.request_type == "set_energy_forecast":
-            self._set_energy_forecast_impl(req.arguments, req.response_channel)
-        elif req.request_type == "set_energy_measurement":
-            self._set_energy_measurement_impl(req.arguments, req.response_channel)
-        else:
-            super()._incoming_commands_callback_selection(req)
-
-    def event_market_cycle(self) -> None:
-        """Update forecast and measurement in state by reading from buffers."""
-        self.update_energy_forecast()
-        self.update_energy_measurement()
-        self._clear_energy_buffers()
-        super().event_market_cycle()
-
-    def _clear_energy_buffers(self) -> None:
-        """Clear forecast and measurement buffers."""
-        self.energy_forecast_buffer = {}
-        self.energy_measurement_buffer = {}
-
-    def event_activate_energy(self) -> None:
-        """This strategy does not need to initiate energy values as they are sent via the API."""
-        self._clear_energy_buffers()
-
     def update_energy_forecast(self) -> None:
         """Set energy forecast for future markets."""
         for slot_time, energy_kWh in self.energy_forecast_buffer.items():
@@ -454,11 +398,3 @@ class PVForecastExternalStrategy(PVPredefinedExternalStrategy):
         for slot_time, energy_kWh in self.energy_measurement_buffer.items():
             if slot_time < self.area.spot_market.time_slot:
                 self.state.set_energy_measurement_kWh(energy_kWh, slot_time)
-
-    def set_produced_energy_forecast_kWh_future_markets(self, reconfigure=False) -> None:
-        """
-        Setting produced energy for the next slot is already done by produced_energy_forecast_kWh
-        """
-
-    def _read_or_rotate_profiles(self, reconfigure=False) -> None:
-        """Overridden with empty implementation to disable reading profile from DB."""

--- a/src/d3a/models/strategy/external_strategies/storage.py
+++ b/src/d3a/models/strategy/external_strategies/storage.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 class StorageExternalMixin(ExternalMixin):
 
     state: "StorageState"
-    offers: Offers
+    offers: "Offers"
     post_offer: Callable
     is_bid_posted: Callable
     remove_bid_from_pending: Callable

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
 	coverage
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/tests.txt
+    pip-sync requirements/tests.txt requirements/pandapower.txt
     pip install -e .
 	pip uninstall -y d3a-interface
 	pip install git+https://github.com/gridsingularity/d3a-interface@{env:BRANCH:master}


### PR DESCRIPTION
This PR deals with the following: 
- moving the forecast and measurement part of the external strategies from ExternalMixin to their own mixin, in order for the ExternalMixin to include only code that is always necessary for every mixin (need to extend this in order to abstract BidExternalMixin and OfferExternalMixin too)
- declaring the dependencies of the mixins as type hints, in order to have more clarity over which members does the mixed-in  class need to have in order for the mixin to work correctly. 

The initial approach to declare abstract methods for all the needed members did not work out unfortunately, because the Mixins need to precede the class that inherits them in the MRO order (in order to override methods that the mixed-in strategy class defines, e.g. event_tick). Therefore by declaring these methods as abstract the concrete class would end up with abstract method implementations, therefore raising an error when calling them. 