### PR TITLE
D3ASIM-3649: Add Pylint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: ["flake8-tuple"]
+-   repo: https://github.com/PyCQA/pylint
+    rev: v2.11.1
+    hooks:
+    - id: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -144,7 +144,8 @@ disable=invalid-name,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        missing-module-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,6 @@
 -r base.txt
 
 fabric3
+pre-commit
 psutil
 pyyaml>=4.2b1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -138,6 +138,7 @@ pony==0.7.14
 pre-commit==2.15.0
     # via
     #   -r requirements/base.txt
+    #   -r requirements/dev.in
     #   d3a-interface
 psutil==5.8.0
     # via -r requirements/dev.in


### PR DESCRIPTION
- Add Pylint as a pre-commit hook
- disable `missing-module-docstring` warnings