### PR TITLE
Use local Pylint executable in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,11 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: ["flake8-tuple"]
--   repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+-   repo: local
     hooks:
     - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      description: "Use local Pylint to be able to follow imports of local dependencies"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,4 +3,5 @@
 fabric3
 pre-commit
 psutil
+pylint
 pyyaml>=4.2b1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,8 @@
 #
 -e git+https://github.com/gridsingularity/d3a-interface@master#egg=d3a_interface
     # via -r requirements/base.txt
+astroid==2.8.4
+    # via pylint
 attrs==21.2.0
     # via
     #   -r requirements/base.txt
@@ -90,6 +92,8 @@ idna==2.10
     #   -r requirements/base.txt
     #   d3a-interface
     #   requests
+isort==5.10.0
+    # via pylint
 jsonschema==4.1.2
     # via
     #   -r requirements/base.txt
@@ -98,11 +102,14 @@ kafka-python==2.0.2
     # via
     #   -r requirements/base.txt
     #   d3a-interface
+lazy-object-proxy==1.6.0
+    # via astroid
 mccabe==0.6.1
     # via
     #   -r requirements/base.txt
     #   d3a-interface
     #   flake8
+    #   pylint
 nodeenv==1.6.0
     # via
     #   -r requirements/base.txt
@@ -125,6 +132,7 @@ platformdirs==2.4.0
     # via
     #   -r requirements/base.txt
     #   d3a-interface
+    #   pylint
     #   virtualenv
 plotly==5.3.1
     # via -r requirements/base.txt
@@ -159,6 +167,8 @@ pyflakes==2.1.1
     #   -r requirements/base.txt
     #   d3a-interface
     #   flake8
+pylint==2.11.1
+    # via -r requirements/dev.in
 pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
@@ -234,11 +244,16 @@ toml==0.10.2
     #   -r requirements/base.txt
     #   d3a-interface
     #   pre-commit
+    #   pylint
     #   tox
 tox==3.24.4
     # via
     #   -r requirements/base.txt
     #   d3a-interface
+typing-extensions==3.10.0.2
+    # via
+    #   astroid
+    #   pylint
 unidecode==0.4.21
     # via
     #   -r requirements/base.txt
@@ -258,3 +273,8 @@ websockets==10.0
     # via
     #   -r requirements/base.txt
     #   d3a-interface
+wrapt==1.13.3
+    # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/pandapower.txt
+++ b/requirements/pandapower.txt
@@ -6,6 +6,10 @@
 #
 -e git+https://github.com/gridsingularity/d3a-interface@master#egg=d3a_interface
     # via -r requirements/dev.txt
+astroid==2.8.4
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
 attrs==21.2.0
     # via
     #   -r requirements/dev.txt
@@ -100,6 +104,10 @@ idna==2.10
     #   -r requirements/dev.txt
     #   d3a-interface
     #   requests
+isort==5.10.0
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
 jsonschema==4.1.2
     # via
     #   -r requirements/dev.txt
@@ -110,6 +118,10 @@ kafka-python==2.0.2
     #   d3a-interface
 kiwisolver==1.3.2
     # via matplotlib
+lazy-object-proxy==1.6.0
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
 matplotlib==3.4.0
     # via -r requirements/pandapower.in
 mccabe==0.6.1
@@ -117,6 +129,7 @@ mccabe==0.6.1
     #   -r requirements/dev.txt
     #   d3a-interface
     #   flake8
+    #   pylint
 networkx==2.6.3
     # via pandapower
 nodeenv==1.6.0
@@ -157,6 +170,7 @@ platformdirs==2.4.0
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+    #   pylint
     #   virtualenv
 plotly==5.3.1
     # via -r requirements/dev.txt
@@ -192,6 +206,8 @@ pyflakes==2.1.1
     #   -r requirements/dev.txt
     #   d3a-interface
     #   flake8
+pylint==2.11.1
+    # via -r requirements/dev.txt
 pynacl==1.4.0
     # via
     #   -r requirements/dev.txt
@@ -275,11 +291,17 @@ toml==0.10.2
     #   -r requirements/dev.txt
     #   d3a-interface
     #   pre-commit
+    #   pylint
     #   tox
 tox==3.24.4
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+typing-extensions==3.10.0.2
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+    #   pylint
 unidecode==0.4.21
     # via
     #   -r requirements/dev.txt
@@ -299,7 +321,14 @@ websockets==10.0
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+wrapt==1.13.3
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
 xlrd==2.0.1
     # via pandapower
 xlsxwriter==3.0.2
     # via pandapower
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,6 +6,10 @@
 #
 -e git+https://github.com/gridsingularity/d3a-interface@master#egg=d3a_interface
     # via -r requirements/dev.txt
+astroid==2.8.4
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
 attrs==21.2.0
     # via
     #   -r requirements/dev.txt
@@ -107,8 +111,11 @@ idna==2.10
     #   requests
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
-    # via -r requirements/tests.in
+isort==5.10.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/tests.in
+    #   pylint
 jsonschema==4.1.2
     # via
     #   -r requirements/dev.txt
@@ -117,11 +124,16 @@ kafka-python==2.0.2
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+lazy-object-proxy==1.6.0
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
 mccabe==0.6.1
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
     #   flake8
+    #   pylint
 nodeenv==1.6.0
     # via
     #   -r requirements/dev.txt
@@ -157,6 +169,7 @@ platformdirs==2.4.0
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+    #   pylint
     #   virtualenv
 plotly==5.3.1
     # via -r requirements/dev.txt
@@ -194,6 +207,8 @@ pyflakes==2.1.1
     #   -r requirements/dev.txt
     #   d3a-interface
     #   flake8
+pylint==2.11.1
+    # via -r requirements/dev.txt
 pynacl==1.4.0
     # via
     #   -r requirements/dev.txt
@@ -282,12 +297,18 @@ toml==0.10.2
     #   -r requirements/dev.txt
     #   d3a-interface
     #   pre-commit
+    #   pylint
     #   pytest
     #   tox
 tox==3.24.4
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+typing-extensions==3.10.0.2
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+    #   pylint
 unidecode==0.4.21
     # via
     #   -r requirements/dev.txt
@@ -307,3 +328,10 @@ websockets==10.0
     # via
     #   -r requirements/dev.txt
     #   d3a-interface
+wrapt==1.13.3
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
`pre-commit` installs its hooks (e.g. `pylint`) in a separate virtual environment. In this virtualenv we don’t have any of the libraries needed by our code (e.g. d3a-interface) so this version of pylint raises errors.

This PR allows using the local executable of Pylint (from the current virtual env) to avoid this kind of issues.