### PR TITLE
D3ASIM-3635: Removed market_count from the d3a-interface.

### DIFF
--- a/src/d3a/models/myco_matcher/myco_internal_matcher.py
+++ b/src/d3a/models/myco_matcher/myco_internal_matcher.py
@@ -60,6 +60,8 @@ class MycoInternalMatcher(MycoMatcherInterface):
         for area_uuid, area_data in self.area_uuid_markets_mapping.items():
             for market_type in ["markets", "settlement_markets"]:
                 for market in area_data[market_type]:
+                    if not market:
+                        continue
                     while True:
                         bids, offers = market.open_bids_and_offers()
                         data = {
@@ -81,6 +83,8 @@ class MycoInternalMatcher(MycoMatcherInterface):
         """Loop over all future markets and match bids and offers."""
         for area_uuid, area_data in self.area_uuid_markets_mapping.items():
             future_markets = area_data["future_markets"]
+            if not future_markets:
+                continue
             for time_slot in future_markets.market_time_slots:
                 while True:
                     bids, offers = future_markets.open_bids_and_offers(time_slot=time_slot)


### PR DESCRIPTION
Resolves this exception that was raised on dev environment:

Traceback (most recent call last):
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/d3a_core/rq_job_handler.py", line 125, in launch_simulation_from_rq_job
Nov 3, 2021 @ 11:50:24.822    kwargs=kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/d3a_core/simulation.py", line 622, in run_simulation
Nov 3, 2021 @ 11:50:24.822    simulation.run()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/d3a_core/simulation.py", line 228, in run
Nov 3, 2021 @ 11:50:24.822    else self._execute_simulation(initial_slot, tick_resume)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/d3a_core/simulation.py", line 379, in _execute_simulation
Nov 3, 2021 @ 11:50:24.822    self.area.tick_and_dispatch()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/__init__.py", line 458, in tick_and_dispatch
Nov 3, 2021 @ 11:50:24.822    self.dispatcher.broadcast_tick()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 91, in broadcast_tick
Nov 3, 2021 @ 11:50:24.822    self.broadcast_notification(AreaEvent.TICK, **kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 161, in broadcast_notification
Nov 3, 2021 @ 11:50:24.822    child.dispatcher.event_listener(event_type, **kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 186, in event_listener
Nov 3, 2021 @ 11:50:24.822    self.area.tick_and_dispatch()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/__init__.py", line 458, in tick_and_dispatch
Nov 3, 2021 @ 11:50:24.822    self.dispatcher.broadcast_tick()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 91, in broadcast_tick
Nov 3, 2021 @ 11:50:24.822    self.broadcast_notification(AreaEvent.TICK, **kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 161, in broadcast_notification
Nov 3, 2021 @ 11:50:24.822    child.dispatcher.event_listener(event_type, **kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/event_dispatcher.py", line 186, in event_listener
Nov 3, 2021 @ 11:50:24.822    self.area.tick_and_dispatch()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/__init__.py", line 459, in tick_and_dispatch
Nov 3, 2021 @ 11:50:24.822    self.tick()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/area/__init__.py", line 425, in tick
Nov 3, 2021 @ 11:50:24.822    bid_offer_matcher.match_recommendations()
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/myco_matcher/myco_matcher.py", line 53, in match_recommendations
Nov 3, 2021 @ 11:50:24.822    self.matcher.match_recommendations(**kwargs)
Nov 3, 2021 @ 11:50:24.822  File "/app/src/d3a/models/myco_matcher/myco_internal_matcher.py", line 64, in match_recommendations
Nov 3, 2021 @ 11:50:24.822    bids, offers = market.open_bids_and_offers()
Nov 3, 2021 @ 11:50:24.822AttributeError: 'NoneType' object has no attribute 'open_bids_and_offers'