### PR TITLE
Timezone integration tests

### DIFF
--- a/integration_tests/steps/storage_test.py
+++ b/integration_tests/steps/storage_test.py
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=no-name-in-module
 from behave import then
 from d3a_interface.read_user_profile import read_arbitrary_profile, InputProfileTypes
-from pendulum import duration
 
 from d3a.constants import DEFAULT_PRECISION
 from d3a.setup.strategy_tests.storage_strategy_break_even_hourly import (
@@ -61,7 +60,6 @@ def step_impl(context):
                                                         final_buying_rate_profile_2)
     final_selling_rate_storage2 = read_arbitrary_profile(InputProfileTypes.IDENTITY,
                                                          final_selling_rate_profile_2)
-    start_time_stamp = next(iter(final_buying_rate_storage1.keys()))
     for name, final_buying_rate, final_selling_rate in \
             [("H1 Storage1", final_buying_rate_storage1, final_selling_rate_storage1),
              ("H1 Storage2", final_buying_rate_storage2, final_selling_rate_storage2)]:
@@ -69,14 +67,13 @@ def step_impl(context):
         trades_bought = []
         for market in house1.past_markets:
             for trade in market.trades:
-                expected_time_stamp = start_time_stamp + duration(hours=trade.creation_time.hour)
                 if trade.seller == name:
                     assert (round(trade.offer_bid.energy_rate, 2) >=
-                            round(final_selling_rate[expected_time_stamp], 2))
+                            round(final_selling_rate[market.time_slot], 2))
                     trades_sold.append(trade)
                 elif trade.buyer == name:
                     assert (round(trade.offer_bid.energy_rate, 2) <=
-                            round(final_buying_rate[expected_time_stamp], 2))
+                            round(final_buying_rate[market.time_slot], 2))
                     trades_bought.append(trade)
 
         assert len(trades_sold) > 0

--- a/src/d3a/d3a_core/user_profile_handler.py
+++ b/src/d3a/d3a_core/user_profile_handler.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict
 
 import pytz
@@ -61,7 +61,7 @@ class ProfileDBConnectionHandler:
     @staticmethod
     def strip_timezone_and_create_pendulum_instance_from_datetime(
             time_stamp: datetime) -> DateTime:
-        return instance(time_stamp.astimezone(timezone.utc), pytz.UTC)
+        return instance(time_stamp).in_timezone('UTC')
 
     def connect(self):
         """ Establishes a connection to the d3a-profiles DB

--- a/src/d3a/d3a_core/user_profile_handler.py
+++ b/src/d3a/d3a_core/user_profile_handler.py
@@ -39,11 +39,13 @@ class ProfileDBConnectionHandler:
     _db = Database()
 
     class Profile_Database_ProfileTimeSeries(_db.Entity):
+        """Model for the profile timeseries data"""
         profile_uuid = Required(uuid.UUID)
         time = Required(datetime)
         value = Required(float)
 
     class Profile_Database_ConfigurationAreaProfileUuids(_db.Entity):
+        """Model for the information associated with each profile"""
         configuration_uuid = Required(uuid.UUID)
         area_uuid = Required(uuid.UUID)
         profile_uuid = Required(uuid.UUID)
@@ -55,13 +57,13 @@ class ProfileDBConnectionHandler:
         self._profile_uuids = None
 
     @staticmethod
-    def convert_pendulum_to_datetime(time_stamp):
+    def _convert_pendulum_to_datetime(time_stamp):
         return datetime.fromtimestamp(time_stamp.timestamp(), tz=pytz.UTC)
 
     @staticmethod
-    def strip_timezone_and_create_pendulum_instance_from_datetime(
+    def _strip_timezone_and_create_pendulum_instance_from_datetime(
             time_stamp: datetime) -> DateTime:
-        return instance(time_stamp).in_timezone('UTC')
+        return instance(time_stamp).in_timezone("UTC")
 
     def connect(self):
         """ Establishes a connection to the d3a-profiles DB
@@ -108,7 +110,7 @@ class ProfileDBConnectionHandler:
         )
 
         datapoint_dict = {
-            self.strip_timezone_and_create_pendulum_instance_from_datetime(datapoint.time).set(
+            self._strip_timezone_and_create_pendulum_instance_from_datetime(datapoint.time).set(
                 year=current_timestamp.year,
                 month=current_timestamp.month,
                 day=current_timestamp.day
@@ -158,18 +160,18 @@ class ProfileDBConnectionHandler:
             current_timestamp (Datetime): Current pendulum time stamp
         """
         start_time, end_time = self._get_start_end_time(current_timestamp)
-        query_ret_val = self._get_profiles_from_db(self.convert_pendulum_to_datetime(start_time),
-                                                   self.convert_pendulum_to_datetime(end_time))
+        query_ret_val = self._get_profiles_from_db(self._convert_pendulum_to_datetime(start_time),
+                                                   self._convert_pendulum_to_datetime(end_time))
 
         for profile_uuid in self._profile_uuids:
             self._user_profiles[profile_uuid] = {
-                self.strip_timezone_and_create_pendulum_instance_from_datetime(
+                self._strip_timezone_and_create_pendulum_instance_from_datetime(
                     data_point.time): data_point.value
                 for data_point in query_ret_val if data_point.profile_uuid == profile_uuid
             }
 
-        for profile_uuid in self._user_profiles:
-            if not self._user_profiles[profile_uuid]:
+        for profile_uuid, profile_timeseries in self._user_profiles.items():
+            if not profile_timeseries:
                 self._user_profiles[profile_uuid] = self.get_first_week_from_profile(
                     profile_uuid, current_timestamp)
 
@@ -195,7 +197,7 @@ class ProfileDBConnectionHandler:
         time_stamps = generate_market_slot_list(current_timestamp)
         return min(time_stamps), max(time_stamps)
 
-    def should_buffer_profiles(self, current_timestamp: DateTime):
+    def _should_buffer_profiles(self, current_timestamp: DateTime):
         return (self._profile_uuids is None or
                 (not self._buffered_times or (current_timestamp not in self._buffered_times)))
 
@@ -207,7 +209,7 @@ class ProfileDBConnectionHandler:
                                           that is used to decide whether to buffer or not
 
         """
-        if self.should_buffer_profiles(current_timestamp):
+        if self._should_buffer_profiles(current_timestamp):
             self._buffer_profile_uuid_list()
             self._buffer_all_profiles(current_timestamp)
             self._buffer_time_slots()
@@ -237,16 +239,17 @@ class ProfilesHandler:
 
     def activate(self):
         """Connect to DB, update current timestamp and get the first chunk of data from the DB"""
-        self.connect_to_db()
+        self._connect_to_db()
         self.update_time_and_buffer_profiles(GlobalConfig.start_date)
 
-    def connect_to_db(self):
+    def _connect_to_db(self):
         if d3a.constants.CONNECT_TO_PROFILES_DB:
             self.db = ProfileDBConnectionHandler()
             self.db.connect()
 
     @property
     def current_timestamp(self):
+        """Get the current timestamp of the simulation"""
         return self._current_timestamp
 
     def _update_current_time(self, timestamp: DateTime):

--- a/src/d3a/models/market/balancing.py
+++ b/src/d3a/models/market/balancing.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import uuid
 from typing import Union, Dict, List, Optional  # noqa
-from pendulum import now, DateTime
+from pendulum import DateTime
 from logging import getLogger
 
 from d3a_interface.data_classes import Offer
@@ -30,7 +30,7 @@ from d3a.d3a_core.exceptions import InvalidOffer, MarketReadOnlyException, \
 from d3a.d3a_core.util import short_offer_bid_log_str
 from d3a.d3a_core.device_registry import DeviceRegistry
 from d3a.constants import FLOATING_POINT_TOLERANCE
-from d3a_interface.constants_limits import ConstSettings, TIME_ZONE
+from d3a_interface.constants_limits import ConstSettings
 
 log = getLogger(__name__)
 
@@ -84,9 +84,9 @@ class BalancingMarket(OneSidedMarket):
             offer_id = str(uuid.uuid4())
 
         offer = BalancingOffer(
-            offer_id, now(tz=TIME_ZONE), price, energy, seller,
+            offer_id, self.now, price, energy, seller,
             seller_origin=seller_origin, attributes=attributes,
-            requirements=requirements)
+            requirements=requirements, time_slot=self.time_slot)
         self.offers[offer.id] = offer
 
         self.offer_history.append(offer)
@@ -215,7 +215,7 @@ class BalancingMarket(OneSidedMarket):
             self.bc_interface.handle_blockchain_trade_event(
                 offer, buyer, original_offer, residual_offer
             )
-        trade = BalancingTrade(trade_id, now(tz=TIME_ZONE), offer, offer.seller, buyer,
+        trade = BalancingTrade(trade_id, self.now, offer, offer.seller, buyer,
                                residual_offer, seller_origin=offer.seller_origin,
                                buyer_origin=buyer_origin, fee_price=fees,
                                seller_origin_id=offer.seller_origin_id,

--- a/src/d3a/models/market/one_sided.py
+++ b/src/d3a/models/market/one_sided.py
@@ -20,10 +20,10 @@ from logging import getLogger
 from math import isclose
 from typing import Union, Dict, List, Optional
 
-from d3a_interface.constants_limits import ConstSettings, TIME_ZONE
+from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.data_classes import Offer, Trade, TradeBidOfferInfo
 from d3a_interface.enums import SpotMarketTypeEnum
-from pendulum import DateTime, now
+from pendulum import DateTime
 
 from d3a.d3a_core.exceptions import (InvalidOffer, MarketReadOnlyException, OfferNotFoundException,
                                      InvalidTrade, MarketException)
@@ -115,6 +115,9 @@ class OneSidedMarket(Market):
             raise InvalidOffer()
         if original_price is None:
             original_price = price
+
+        if not time_slot:
+            time_slot = self.time_slot
 
         if adapt_price_with_fees:
             price = self._update_new_offer_price_with_fee(price, original_price, energy)
@@ -313,7 +316,7 @@ class OneSidedMarket(Market):
         offer_bid_trade_info = self.fee_class.propagate_original_bid_info_on_offer_trade(
             trade_original_info=trade_bid_info)
 
-        trade = Trade(trade_id, now(tz=TIME_ZONE), offer, offer.seller, buyer, residual_offer,
+        trade = Trade(trade_id, self.now, offer, offer.seller, buyer, residual_offer,
                       offer_bid_trade_info=offer_bid_trade_info,
                       seller_origin=offer.seller_origin, buyer_origin=buyer_origin,
                       fee_price=fee_price, buyer_origin_id=buyer_origin_id,

--- a/src/d3a/models/market/two_sided.py
+++ b/src/d3a/models/market/two_sided.py
@@ -22,10 +22,10 @@ from logging import getLogger
 from math import isclose
 from typing import Dict, List, Union, Tuple, Optional
 
-from d3a_interface.constants_limits import ConstSettings, TIME_ZONE
+from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.data_classes import Bid, Offer, Trade, TradeBidOfferInfo, BidOfferMatch
 from d3a_interface.matching_algorithms.requirements_validators import RequirementsSatisfiedChecker
-from pendulum import DateTime, now
+from pendulum import DateTime
 
 from d3a.constants import FLOATING_POINT_TOLERANCE
 from d3a.d3a_core.exceptions import (BidNotFoundException, InvalidBid,
@@ -103,6 +103,9 @@ class TwoSidedMarket(OneSidedMarket):
         if energy <= 0:
             raise InvalidBid()
 
+        if not time_slot:
+            time_slot = self.time_slot
+
         if original_price is None:
             original_price = price
 
@@ -113,7 +116,7 @@ class TwoSidedMarket(OneSidedMarket):
             raise MarketException("Negative price after taxes, bid cannot be posted.")
 
         bid = Bid(str(uuid.uuid4()) if bid_id is None else bid_id,
-                  now(tz=TIME_ZONE), price, energy, buyer, original_price, buyer_origin,
+                  self.now, price, energy, buyer, original_price, buyer_origin,
                   buyer_origin_id=buyer_origin_id, buyer_id=buyer_id,
                   attributes=attributes, requirements=requirements, time_slot=time_slot)
 
@@ -245,7 +248,7 @@ class TwoSidedMarket(OneSidedMarket):
             trade_offer_info, ignore_fees=True
         )
 
-        trade = Trade(str(uuid.uuid4()), now(tz=TIME_ZONE), bid, seller,
+        trade = Trade(str(uuid.uuid4()), self.now, bid, seller,
                       buyer, residual_bid, already_tracked=already_tracked,
                       offer_bid_trade_info=updated_bid_trade_info,
                       buyer_origin=bid.buyer_origin, seller_origin=seller_origin,

--- a/tests/market/test_market.py
+++ b/tests/market/test_market.py
@@ -78,6 +78,24 @@ def test_market_offer(market, offer):
     assert e_offer.price == 10
     assert e_offer.seller == "someone"
     assert len(e_offer.id) == 36
+    assert e_offer.creation_time == market.now
+    assert e_offer.time_slot == market.time_slot
+
+
+@pytest.mark.parametrize("market", [
+    TwoSidedMarket(bc=NonBlockchainInterface(str(uuid4())), time_slot=now()),
+    SettlementMarket(bc=NonBlockchainInterface(str(uuid4())), time_slot=now())
+])
+def test_market_bid(market):
+    ConstSettings.BalancingSettings.ENABLE_BALANCING_MARKET = True
+    bid = market.bid(10, 20, "someone", "someone")
+    assert market.bids[bid.id] == bid
+    assert bid.energy == 20
+    assert bid.price == 10
+    assert bid.buyer == "someone"
+    assert len(bid.id) == 36
+    assert bid.creation_time == market.now
+    assert bid.time_slot == market.time_slot
 
 
 def test_market_offer_invalid(market: OneSidedMarket):
@@ -131,7 +149,8 @@ def test_market_trade(market, offer, accept_offer):
     assert trade
     assert trade == market.trades[0]
     assert trade.id
-    assert trade.creation_time > e_offer.creation_time
+    assert trade.creation_time == market.now
+    assert trade.time_slot == market.time_slot
     assert trade.offer_bid == e_offer
     assert trade.seller == "A"
     assert trade.buyer == "B"
@@ -144,7 +163,8 @@ def test_balancing_market_negative_offer_trade(market=BalancingMarket(
     assert trade
     assert trade == market.trades[0]
     assert trade.id
-    assert trade.creation_time > offer.creation_time
+    assert trade.creation_time == market.now
+    assert trade.time_slot == market.time_slot
     assert trade.offer_bid is offer
     assert trade.seller == "A"
     assert trade.buyer == "B"


### PR DESCRIPTION
Solved the failing "Strategies follow yearly user profile saved in the DB" integration test, which could be reproduced only in local environments and not on CI nor production. The root cause of the bug was that the profile timeseries that are stored in the database were timezone-aware, therefore there are conversion methods that translate any timezone in the DB to UTC. However, the default Python timezone methods (`astimezone`) do not take into account DST, therefore in any environment with a local timezone with DST, the integration tests were failing. CI and production remained unaffected because they were running on UTC time anyways. 
Solution was to move from Python timezone methods to pendulum timezone methods, which solved the problem and translated the timezones taking into account DST as expected.